### PR TITLE
YouTube-Links (📺) konsequent auf html-only setzen

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -79,8 +79,11 @@ Diese Begleitvideos helfen Ihnen bei der Vor- und Nachbereitung dieses Kapitels:
 - [Video zur Inferenz, Teil 2](https://youtu.be/QNMVi6IqQ90)
 
 
+::: {.content-visible when-format="html"}
 📺 [Wozu ist Statistik eigentlich da?](https://www.youtube.com/watch?v=gcwWwBy0kPI&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=2)
-Diese Frage haben Sie sich auch schon mal gestellt? 
+:::
+
+Diese Frage haben Sie sich auch schon mal gestellt?
 Abb. @fig-goals gibt einen Überblick über die drei Zielarten der statistikbasierten wissenschaftlichen Forschung.^[Ziele existieren nicht "in echt" in der Welt. Wir denken sie uns aus.
 Ziele haben also keine ontologische Wirklichkeit,
 sie sind epistemologische Dinge (existieren nur in unserem Kopf).

--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -1409,7 +1409,9 @@ p_F_emp
 #### Grundlagen
 
 
+::: {.content-visible when-format="html"}
 📺 [Verteilungen metrischer Zufallsvariablen](https://www.youtube.com/watch?v=7GqIE4sKDs4&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=4)
+:::
 
 @fig-zv-stetig-groesse versinnbildlicht die stetige Zufallsvariable "Körpergröße", die (theoretisch, in Annäherung) jeden beliebigen Wert zwischen 0 und (vielleicht) 2 Meter annehmen kann.
 

--- a/0400-Verteilungen.qmd
+++ b/0400-Verteilungen.qmd
@@ -134,7 +134,9 @@ Die Folien zu diesem Kapitel finden Sie [hier](slides/0400-Verteilungen.html).
 
 Im Folgenden sind einige wichtige Verteilungen aufgeführt, die in diesem Skript (und in der Statistik und Wahrscheinlichkeitstheorie) eine zentrale Rolle spielen.
 
+::: {.content-visible when-format="html"}
 📺 [Einstieg in Verteilungen](https://www.youtube.com/watch?v=HKWwondYsW8&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=5)
+:::
 
 ## Gleichverteilung
 

--- a/0500-Globusversuch.qmd
+++ b/0500-Globusversuch.qmd
@@ -1054,7 +1054,9 @@ E) Hat eine Hypothese die höchste Likelihood, so hat sie automatisch auch die h
 ### Zusammenfassung
 
 
+::: {.content-visible when-format="html"}
 📺 [Übung zum Globusversuch](https://www.youtube.com/watch?v=YJEZiQvCBgs&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=7)
+:::
 
 - In unserem Modell haben wir Annahmen zu $Pr_{Apriori}$ und $L$ getroffen.
 - Auf dieser Basis hat der Golem sein Wissen geupdated zu $Pr_{Post}$.

--- a/0600-Post.qmd
+++ b/0600-Post.qmd
@@ -654,7 +654,9 @@ $\square$
 So, jetzt befragen wir die Post-Verteilung.
 
 
+::: {.content-visible when-format="html"}
 📺 [Die Post-Verteilung auslesen](https://www.youtube.com/watch?v=yjCMgf6VkLs)
+:::
 
 
 :::callout-important

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -439,7 +439,9 @@ Das Schwierigste ist dabei nur, nicht zu vergessen, dass `kung_zentriert` die Ta
 
 ## Modell m_kung_gewicht_c: zentrierter Prädiktor
 
+::: {.content-visible when-format="html"}
 📺 [Prädiktoren zentrieren](https://youtu.be/3Z1dXPO_MSE)
+:::
 
 Erstellen wir nun ein Regressionsmodell mit dem zentrierten Prädiktor, Gewicht.
 Die Forschungsfrage lautet: "Wie stark ist der lineare Zusammenhang von Größe und Gewicht?".
@@ -652,9 +654,11 @@ Welche Aussage zur Herleitung der *Körpergrößen*, $h_i$, ist korrekt?
 ## Die Post-Verteilung befragen
 
 
+::: {.content-visible when-format="html"}
 📺 [Post-Verteilung auslesen 1](https://youtu.be/9ZUyN4GUNBY)
 
 📺 [Post-Verteilung auslesen 2](https://youtu.be/8NrUQ1_d7vI)
+:::
 
 ### `m_kung_starkes_beta1`
 

--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -2611,9 +2611,11 @@ Legen Sie beim Verlassen des Raumes Ihre Zettel vorne bei der Lehrkraft ab (anon
 Eine Kurzdarstellung des Bayes-Inferenz findet sich [in diesem Post](https://sebastiansauer.github.io/data_se/2022/01/27/bayes-in-f%C3%BCnf-minuten/) und in [diesem](https://sebastiansauer.github.io/data_se/2022/01/28/bayes-in-f%C3%BCnf-minuten-f%C3%BCr-fortgeschrittene/).
 
 
+::: {.content-visible when-format="html"}
 📺 [Musterlösung und Aufgabe im Detail besprochen -- Bayes-Modell: mtcars](https://www.youtube.com/watch?v=Yoo8IcmwRWg)
 
 📺 [Musterlösung und Aufgabe im Detail besprochen -- Bayes-Modell: CovidIstress](https://www.youtube.com/watch?v=5A5bDNeB6sA)
+:::
 
 
 

--- a/1150-konfundierung.qmd
+++ b/1150-konfundierung.qmd
@@ -486,7 +486,9 @@ Wolfie, Post-Nerd, kommt in dieser Geschichte aber nicht vor
 
 ::::
 
+::: {.content-visible when-format="html"}
 📺 [Don und Angie](https://www.youtube.com/watch?v=LslpcT8aosI)
+:::
 
 
 

--- a/1180-kausalatome.qmd
+++ b/1180-kausalatome.qmd
@@ -977,7 +977,9 @@ Hier ist ein Rezept, das Ihnen zeigt, welche Variablen Sie kontrollieren sollten
 
 
 
+::: {.content-visible when-format="html"}
 📺 [Hintertür schließen](https://www.youtube.com/watch?v=Hns1UIYKTds)
+:::
 
 
 ### Hintertür: ja oder nein?
@@ -1115,9 +1117,11 @@ impliedConditionalIndependencies(dag_6.2)
 
 ### Ausstieg
 
+::: {.content-visible when-format="html"}
 📺 [Musterlösung für eine DAG-Prüfungsaufgabe](https://www.youtube.com/watch?v=lHUEURFjW78)
 
 📺 [Musterlösung für schwierige DAG-Prüfungsaufgaben](https://www.youtube.com/watch?v=5HKmOdzuDXw)
+:::
 
 :::{#exm-pmi-kausal1}
 ### PMI zum heutigen Stoff
@@ -1141,7 +1145,9 @@ Reichen Sie die Antworten an der von der Lehrkraft angezeigten Stelle ein! $\squ
 ### Zusammenfassung
 
 
+::: {.content-visible when-format="html"}
 📺 [Kausalmodelle überprüfen](https://www.youtube.com/watch?v=JEHgAJEdIa0)
+:::
 
 Wie (und sogar ob) Sie statistische Ergebnisse (z.B. eines Regressionsmodells) interpretieren können, hängt von der *epistemologischen Zielrichtung* der Forschungsfrage ab:
 

--- a/1200-abschluss.qmd
+++ b/1200-abschluss.qmd
@@ -297,9 +297,11 @@ $$\mu_1 > \mu_2 \Leftrightarrow \mu_1 - \mu_2 > 0 \Leftrightarrow \mu_d > 0$$
 ## Kerngedanken Bayes
 
 
+::: {.content-visible when-format="html"}
 📺 [Bayes in fünf Minuten](https://www.youtube.com/watch?v=yfOppH_2uSI)
 
 📺 [Bayes in zehn Minuten](https://www.youtube.com/watch?v=8a75ZnyycFc)
+:::
 
 ### Zentraler Kennwert der Bayes-Statistik: Post-Verteilung
 

--- a/children/Wissenschaft-Gerechtigkeit.qmd
+++ b/children/Wissenschaft-Gerechtigkeit.qmd
@@ -3,7 +3,9 @@
 ## Wissenschaft als Gerechtigkeitsprojekt
 
 
+::: {.content-visible when-format="html"}
 📺 [Gängige Forschungsfragen mit Bayes-Regression untersuchen](https://youtu.be/WQOmGUyMkxU)
+:::
 
 ### Meinungen als Grundlage der Konfliktlösung ?
 


### PR DESCRIPTION
Alle bisher nicht umschlossenen 📺-Videolinks werden jetzt per ::: {.content-visible when-format="html"} nur im HTML-Format gerendert, analog zu bereits vorhandenen Fällen (z.B. in 0250-inferenz.qmd).