### PR TITLE
Abb. 4.30 und 4.31 (Bus-Wartezeit) auf 75% Breite verkleinern

### DIFF
--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -1464,7 +1464,7 @@ Nicht so einfach (?). Hingegen ist die Frage, wie hoch die Wahrscheinlichkeit is
 
 ::: {.column width="50%"}
 
-![Wie groß ist die Wahrscheinlichkeit, zwischen 0 und 5 Minuten auf den Bus zu warten? 50 Prozent!](img/p_bus2.png){#fig-bus}
+![Wie groß ist die Wahrscheinlichkeit, zwischen 0 und 5 Minuten auf den Bus zu warten? 50 Prozent!](img/p_bus2.png){#fig-bus width=75%}
 
 
 :::
@@ -1475,7 +1475,7 @@ Nicht so einfach (?). Hingegen ist die Frage, wie hoch die Wahrscheinlichkeit is
 #| fig-cap: "Wie groß ist die Wahrscheinlichkeit, genau 42 Sekunden auf den Bus zu warten? Hm."
 #| label: fig-p42
 #| warning: false
-#| out-width: 100%
+#| out-width: 75%
 
 p_bus1 <- 
   uniform_Plot(0, 10) + 


### PR DESCRIPTION
Waren im PDF-Export zu groß.