### PR TITLE
Abb. 13.7: Facetten-Header umbrechen und Bild auf 100% Breite

### DIFF
--- a/1150-konfundierung.qmd
+++ b/1150-konfundierung.qmd
@@ -805,6 +805,7 @@ Don!"
 #| label: fig-m2-negativ
 #| fig-cap: "Hauspreis stratifizieren"
 #| fig-asp: 0.5
+#| out-width: "100%"
 #| warning: false
 #| results: hide
 d_size_group <-
@@ -829,10 +830,10 @@ d_m2a <-
   )
 
 size_group_labs <-
-  c(`1` = "sehr kleine Häuser (q1)",
-    `2` = "eher kleine Häuser (q2)",
-    `3` = "eher große Häuser (q3)",
-    `4` = "sehr große Häuser (q4)")
+  c(`1` = "sehr kleine\nHäuser (q1)",
+    `2` = "eher kleine\nHäuser (q2)",
+    `3` = "eher große\nHäuser (q3)",
+    `4` = "sehr große\nHäuser (q4)")
 
 d_size_group |>
   ggplot(aes(x = bedrooms, y = price)) +


### PR DESCRIPTION
Die Facetten-Titel waren zu lang und wurden abgeschnitten; ein Zeilenumbruch macht sie lesbar.