### PR TITLE
Schmales geschütztes Leerzeichen vor % in Tabellenbeschriftung Tbl 7.2

### DIFF
--- a/0500-Globusversuch.qmd
+++ b/0500-Globusversuch.qmd
@@ -905,7 +905,7 @@ Die Bayesbox (@tbl-globus) zeigt, wie sich die Post-Verteilung berechnet.
 
 ```{r QM2-Thema2-kleineModelle-29}
 #| label: tbl-globus
-#| tbl-cap: "Die Bayesbox für den Globusversuch, k=6 Treffer, n=9 Versuche, Apriori-Wahrscheinlichkeit Pr(H)=9%, und Wasseranteile p von 0 bis 1"
+#| tbl-cap: "Die Bayesbox für den Globusversuch, k=6 Treffer, n=9 Versuche, Apriori-Wahrscheinlichkeit Pr(H)=9 %, und Wasseranteile p von 0 bis 1"
 #| echo: false
 bayesbox_globusversuch |> 
   mutate(id = 1:11) |> 


### PR DESCRIPTION
Die Bayesbox-Beschriftung (Pr(H)=9%) wurde beim vorherigen NNBSP-Durchlauf übersehen, weil sie im R-Chunk-Header (tbl-cap) statt im Fließtext steht.