### PR TITLE
definitions.qmd/theorems.qmd neu generiert (fehlerhafte Formatierung …

### DIFF
--- a/definitions.qmd
+++ b/definitions.qmd
@@ -9,9 +9,9 @@
 
 1. **Alternativhypothese (Effekthypothese)**: @def-alternativhyp
 
-1. **#Binomialkoeffizient**: @def-binkoeff
+1. **Binomialkoeffizient**: @def-binkoeff
 
-1. ****Binomialverteilung****: @def-binvert
+1. **Binomialverteilung**: @def-binvert
 
 1. **Blockieren**: @def-blocking
 

--- a/theorems.qmd
+++ b/theorems.qmd
@@ -17,7 +17,7 @@
 
 1. **Binomialverteilung**: @thm-binomial
 
-1. ****Notation für eine binomialverteilte Zufallsvariable****: @thm-binvert
+1. **Notation für eine binomialverteilte Zufallsvariable**: @thm-binvert
 
 1. **Man kann die Regression als Korrelation verstehen:**: @thm-br
 


### PR DESCRIPTION
…behoben)

get-defs.R und get-thms.R erneut ausgeführt; dabei wurden veraltete Formatierungsfehler in den generierten Listen korrigiert (überzähliges "#" bei "Binomialkoeffizient", doppelte "**" bei "Binomialverteilung" und "Notation für eine binomialverteilte Zufallsvariable").