### PR TITLE
Tabelle 4.2 (tbl-wkeit-desk): rechten Seitenrand-Überlauf im PDF beheben

### DIFF
--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -1220,7 +1220,10 @@ d <- tibble::tribble(
                     "Erwartungswert",                                "Mittelwert",
                            "Varianz",                                   "Varianz"
        )
-gt::gt(d)
+knitr::kable(d) |>
+  kableExtra::kable_styling(full_width = FALSE) |>
+  kableExtra::column_spec(1, width = "5cm") |>
+  kableExtra::column_spec(2, width = "6cm")
 ```
 
 


### PR DESCRIPTION
gt::gt() erzeugt im LaTeX-Export unbrechbare "l"-Spalten (tabular* mit \extracolsep{\fill}); lange deutsche Komposita wie "kumulierte relative Häufigkeitsverteilung" sprengten dadurch die Spaltenbreite um ~54pt über den rechten Textrand hinaus (verifiziert per pdfplumber-Wortkoordinaten gegen die Textbreiten-Median-Analyse aus Schritt 9 des textlayout-ueberarbeitung-Skills). Wechsel auf knitr::kable() + kableExtra::column_spec(width=...) erzeugt p{}-Spalten mit echtem Zeilenumbruch (5cm/6cm, isoliert per pdflatex-Testkompilat gegen die Buch-Textbreite verifiziert, keine Overfull-\hbox-Warnung mehr). HTML-Rendering unverändert, da Browser Tabellenzellen ohnehin umbrechen.