### PR TITLE
QR-Code in Kapitel 1.2 wieder oben bündig mit Text ausrichten

### DIFF
--- a/0100-orga.qmd
+++ b/0100-orga.qmd
@@ -252,7 +252,7 @@ und dann z. B. die [Playlist "R"](https://www.youtube.com/playlist?list=PLRR4R
 Dort finden Sie  *Videos zum Thema dieses Buches*.
 :::
 
-::: {#second-column valign="center"}
+::: {#second-column valign="top"}
 
 ```{r}
 #| echo: false

--- a/children/Exponentialverteilung.qmd
+++ b/children/Exponentialverteilung.qmd
@@ -284,7 +284,7 @@ d.h. Exponentialverteilungen mit verschiedenen Werten für $\lambda$.
 ```{r}
 #| label: tbl-exp
 #| echo: false
-#| tbl-cap: "Median-Werte von Exponentialverteilungen mit verschiedenen Werten für $\lambda$ (lambda). p50: 50%-Quantil (Median), p95: 95%-Quantil (Dieser Wert wird mit 95% Wahrscheinlichkeit nicht überschritten; er bietet sich als *Obere Grenze* der plausiblen Werte an.)"
+#| tbl-cap: "Median-Werte von Exponentialverteilungen mit verschiedenen Werten für $\\lambda$ (lambda). p50: 50%-Quantil (Median), p95: 95%-Quantil (Dieser Wert wird mit 95% Wahrscheinlichkeit nicht überschritten; er bietet sich als *Obere Grenze* der plausiblen Werte an.)"
 d_exp <- 
   tibble(
     lambda = c(100, 50, 25, 10, 8, 4, 2, 1, 1/2, 1/4, 1/8, 1/10, 1/25, 1/50, 1/100),


### PR DESCRIPTION
valign war auf "center" gesetzt (aus einem früheren Commit), wodurch die QR-Code-Spalte relativ zur längeren Textspalte vertikal zentriert statt oben ausgerichtet wurde. Zurück auf valign="top", das CSS-Fix für den Bild-Rand oben (specifics/styles.css) war schon vorhanden.

Nebenbei: Escape-Fehler in tbl-cap-YAML (\lambda) in children/Exponentialverteilung.qmd behoben, der den Buch-Render blockierte.


Claude-Session: https://claude.ai/code/session_01EpfZCH9s7iZbaAoMrZso6A