### PR TITLE
URLs von statistik1.netlify.app auf GitHub Pages umstellen

### DIFF
--- a/0100-orga.qmd
+++ b/0100-orga.qmd
@@ -205,7 +205,7 @@ Für diesen Kurs wird folgendes Wissen vorausgesetzt:
 - grundlegende Kenntnis der Regressionsanalyse
 
 
-Dieses Wissen wird z. B. im [Online-Buch "Statistik1"](https://statistik1.netlify.app/)^[<https://statistik1.netlify.app/>] vermittelt.
+Dieses Wissen wird z. B. im [Online-Buch "Statistik1"](https://sebastiansauer.github.io/statistik1/)^[<https://sebastiansauer.github.io/statistik1/>] vermittelt.
 Alle Inhalte daraus werden in diesem Kurs benötigt.
 Die Kapitel dieses Buches bauen aufeinander auf;
 um einem späteren Kapitel folgen zu können, benötigen Sie den Stoff früherer Kapitel.

--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -66,8 +66,8 @@ Grundlage einer ausführlicheren Erläuterung des Stoffes.
 Bereiten Sie sich im Eigenstudium auf dieses Kapitel vor.
 Lesen Sie dazu folgende Themen:
 
-- [Statistik 1, Kap. "Rahmen"](https://statistik1.netlify.app/010-rahmen)^[<https://statistik1.netlify.app/010-rahmen>]
-- [Statistik 1](https://statistik1.netlify.app/)^[<https://statistik1.netlify.app/>], dort alle Inhalte aller Kapitel zum Thema "Modellieren" bzw. "Regression"
+- [Statistik 1, Kap. "Rahmen"](https://sebastiansauer.github.io/statistik1/010-rahmen)^[<https://sebastiansauer.github.io/statistik1/010-rahmen>]
+- [Statistik 1](https://sebastiansauer.github.io/statistik1/)^[<https://sebastiansauer.github.io/statistik1/>], dort alle Inhalte aller Kapitel zum Thema "Modellieren" bzw. "Regression"
 - [Statistik 1, Abschnitt zur Normalverteilung]()
 
 

--- a/0250-inferenz.qmd
+++ b/0250-inferenz.qmd
@@ -44,8 +44,8 @@ Grundlage einer ausführlicheren Erläuterung des Stoffes.
 
 Bereiten Sie sich im Eigenstudium auf dieses Kapitel vor. Lesen Sie dazu folgende Themen:
 
-- [Statistik 1, Kap. "Rahmen"](https://statistik1.netlify.app/010-rahmen)^[<https://statistik1.netlify.app/010-rahmen>]
-- [Statistik 1, Kap. "Punktmodelle 2"](https://statistik1.netlify.app/070-zusammenhaenge)^[<https://statistik1.netlify.app/070-zusammenhaenge>], insbesondere zu Regressionskoeffizienten
+- [Statistik 1, Kap. "Rahmen"](https://sebastiansauer.github.io/statistik1/010-rahmen)^[<https://sebastiansauer.github.io/statistik1/010-rahmen>]
+- [Statistik 1, Kap. "Punktmodelle 2"](https://sebastiansauer.github.io/statistik1/070-zusammenhaenge)^[<https://sebastiansauer.github.io/statistik1/070-zusammenhaenge>], insbesondere zu Regressionskoeffizienten
 
 ::: {.content-visible when-format="html"}
 ::: {.callout-note}

--- a/0400-Verteilungen.qmd
+++ b/0400-Verteilungen.qmd
@@ -34,8 +34,8 @@ Der Stoff dieses Kapitels deckt sich (weitgehend) mit @bourier2011, Kap. 6.1 und
 
 
 Dieses Kapitel setzt einige Grundbegriffe voraus,
-wie im Buch [Statistik1]() vorgestellt, insbesondere im Kapitel ["Rahmen"](https://statistik1.netlify.app/010-rahmen#was-sind-daten)^[<https://statistik1.netlify.app/010-rahmen#was-sind-daten>].
-Benötigt wird auch der Begriff der [Normalverteilung](https://statistik1.netlify.app/040-verbildlichen#spezialfall-normalverteilung)^[<https://statistik1.netlify.app/040-verbildlichen#spezialfall-normalverteilung>] sowie der Begriff der [Quantile](https://statistik1.netlify.app/050-zusammenfassen.html#quantile)^[<https://statistik1.netlify.app/050-zusammenfassen.html#quantile>].
+wie im Buch [Statistik1]() vorgestellt, insbesondere im Kapitel ["Rahmen"](https://sebastiansauer.github.io/statistik1/010-rahmen#was-sind-daten)^[<https://sebastiansauer.github.io/statistik1/010-rahmen#was-sind-daten>].
+Benötigt wird auch der Begriff der [Normalverteilung](https://sebastiansauer.github.io/statistik1/040-verbildlichen#spezialfall-normalverteilung)^[<https://sebastiansauer.github.io/statistik1/040-verbildlichen#spezialfall-normalverteilung>] sowie der Begriff der [Quantile](https://sebastiansauer.github.io/statistik1/050-zusammenfassen.html#quantile)^[<https://sebastiansauer.github.io/statistik1/050-zusammenfassen.html#quantile>].
 Lesen Sie diese Stellen, wenn Sie den Stoff noch nicht oder nicht mehr beherrschen.
 
 Lesen Sie selbständig, zusätzlich zum Stoff dieses Kapitels, noch in @bourier2011 folgende Abschnitte:
@@ -1038,7 +1038,7 @@ $\square$
 
 ## Die halbe Normalverteilung
 
-[Grundlagen über die Normalverteilung](https://statistik1.netlify.app/040-verbildlichen#spezialfall-normalverteilung)^[<https://statistik1.netlify.app/040-verbildlichen#spezialfall-normalverteilung>] können in @sauer2025 nachgelesen werden.
+[Grundlagen über die Normalverteilung](https://sebastiansauer.github.io/statistik1/040-verbildlichen#spezialfall-normalverteilung)^[<https://sebastiansauer.github.io/statistik1/040-verbildlichen#spezialfall-normalverteilung>] können in @sauer2025 nachgelesen werden.
 
 Ein Spezialfall der Normalverteilung ist die *halbe* (oder halbseitige) Normalverteilung, s. @fig-halbe-nv.
 

--- a/0500-Globusversuch.qmd
+++ b/0500-Globusversuch.qmd
@@ -38,7 +38,7 @@ Sie können ...
 Der Stoff dieses Kapitels deckt einen Teil aus @mcelreath2020, Kap. 2, ab. @mcelreath2020 stellt das Globusmodell mit mehr Erläuterung und etwas mehr theoretischem Hintergrund vor, als es in diesem Kapitel der Fall ist.
 
 
-Lesen Sie zur Vorbereitung in Statistik 1 [@sauer2025] das [Kapitel "Daten Einlesen"](https://statistik1.netlify.app/020-r)^[<https://statistik1.netlify.app/020-r>].
+Lesen Sie zur Vorbereitung in Statistik 1 [@sauer2025] das [Kapitel "Daten Einlesen"](https://sebastiansauer.github.io/statistik1/020-r)^[<https://sebastiansauer.github.io/statistik1/020-r>].
 ::: {.content-visible when-format="html"}
 Das Video [Globusversuch](https://www.youtube.com/watch?v=fGlt9Ld4xzk&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=6) ist hilfreich.
 :::

--- a/0600-Post.qmd
+++ b/0600-Post.qmd
@@ -39,9 +39,9 @@ Der Stoff dieses Kapitels orientiert sich an @mcelreath2020, Kap. 3.1 und 3.2.
 
 Lesen Sie folgende Kapitel zur Vorbereitung im Eigenstudium:
 
-- [Statistik1, Kap. "Daten umformen"](https://statistik1.netlify.app/030-aufbereiten)^[<https://statistik1.netlify.app/030-aufbereiten>]
-- [Statistik1, Kap. "Daten zusammenfassen"](https://statistik1.netlify.app/050-zusammenfassen)^[<https://statistik1.netlify.app/050-zusammenfassen>]
-- [Statistik1, Kap. 6.4 "Quantile"](https://statistik1.netlify.app/050-zusammenfassen.html#quantile)^[<https://statistik1.netlify.app/050-zusammenfassen.html#quantile>]
+- [Statistik1, Kap. "Daten umformen"](https://sebastiansauer.github.io/statistik1/030-aufbereiten)^[<https://sebastiansauer.github.io/statistik1/030-aufbereiten>]
+- [Statistik1, Kap. "Daten zusammenfassen"](https://sebastiansauer.github.io/statistik1/050-zusammenfassen)^[<https://sebastiansauer.github.io/statistik1/050-zusammenfassen>]
+- [Statistik1, Kap. 6.4 "Quantile"](https://sebastiansauer.github.io/statistik1/050-zusammenfassen.html#quantile)^[<https://sebastiansauer.github.io/statistik1/050-zusammenfassen.html#quantile>]
 
 Zusätzlich ist diese Playlist (bei YouTube) nützlich: [Playlist QM2](https://www.youtube.com/watch?v=QNMVi6IqQ90&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN).
 

--- a/0700-ppv.qmd
+++ b/0700-ppv.qmd
@@ -34,7 +34,7 @@ Sie können ...
 
 ### Vorbereitung im Eigenstudium
 
-- [Statistik1, Kap. "Daten verbildlichen"](https://statistik1.netlify.app/040-verbildlichen#vertiefung)^[<https://statistik1.netlify.app/040-verbildlichen#vertiefung>]
+- [Statistik1, Kap. "Daten verbildlichen"](https://sebastiansauer.github.io/statistik1/040-verbildlichen#vertiefung)^[<https://sebastiansauer.github.io/statistik1/040-verbildlichen#vertiefung>]
 
 
 Folgende R-Pakete werden benötigt:

--- a/0800-gauss.qmd
+++ b/0800-gauss.qmd
@@ -25,9 +25,9 @@ Im YouTube-Kanal des Autors finden sich passende Videos wie 📺 [Teil 1](https:
 
 Lesen Sie zur Vorbereitung folgende Kapitel im Eigenstudium:
 
--   [Statistik1, Kap. "Modellgüte"](https://statistik1.netlify.app/060-modellguete)^[<https://statistik1.netlify.app/060-modellguete>]
--   [Statistik1, Kap. "Punktmodelle 2"](https://statistik1.netlify.app/070-zusammenhaenge)^[<https://statistik1.netlify.app/070-zusammenhaenge>]
--   [Statistik1, Abschnitt "Normalverteilung"](https://statistik1.netlify.app/040-verbildlichen#normalverteilung)^[<https://statistik1.netlify.app/040-verbildlichen#normalverteilung>]
+-   [Statistik1, Kap. "Modellgüte"](https://sebastiansauer.github.io/statistik1/060-modellguete)^[<https://sebastiansauer.github.io/statistik1/060-modellguete>]
+-   [Statistik1, Kap. "Punktmodelle 2"](https://sebastiansauer.github.io/statistik1/070-zusammenhaenge)^[<https://sebastiansauer.github.io/statistik1/070-zusammenhaenge>]
+-   [Statistik1, Abschnitt "Normalverteilung"](https://sebastiansauer.github.io/statistik1/040-verbildlichen#normalverteilung)^[<https://sebastiansauer.github.io/statistik1/040-verbildlichen#normalverteilung>]
 
 In diesem Kapitel werden die folgenden R-Pakete benötigt.
 

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -26,8 +26,8 @@ Der Stoff dieses Kapitels orientiert sich an @mcelreath2020, Kap. 4.4.
 
 Lesen Sie zur Vorbereitung folgende Kapitel im Eigenstudium:
 
-- [Statistik1, Kap. "Geradenmodelle 1"](https://statistik1.netlify.app/080-regression1)^[<https://statistik1.netlify.app/080-regression1>]
-- [Statistik1, Abschnitt "*z*-Transformation"](https://statistik1.netlify.app/060-modellguete.html#die-z-transformation)^[<https://statistik1.netlify.app/060-modellguete.html#die-z-transformation>]
+- [Statistik1, Kap. "Geradenmodelle 1"](https://sebastiansauer.github.io/statistik1/080-regression1)^[<https://sebastiansauer.github.io/statistik1/080-regression1>]
+- [Statistik1, Abschnitt "*z*-Transformation"](https://sebastiansauer.github.io/statistik1/060-modellguete.html#die-z-transformation)^[<https://sebastiansauer.github.io/statistik1/060-modellguete.html#die-z-transformation>]
 
 
 
@@ -350,7 +350,7 @@ Je schwerer (je höher das Gewicht einer Person), desto größer (desto höher i
 
 :::{.callout-note}
 Wenn Sie mit der *z*-Transformation nicht vertraut sind,
-macht es Sinn, das Thema (jetzt) zu lernen, s. [hier](https://statistik1.netlify.app/060-modellguete.html#die-z-transformation).^[<https://statistik1.netlify.app/060-modellguete.html#die-z-transformation>] $\square$
+macht es Sinn, das Thema (jetzt) zu lernen, s. [hier](https://sebastiansauer.github.io/statistik1/060-modellguete.html#die-z-transformation).^[<https://sebastiansauer.github.io/statistik1/060-modellguete.html#die-z-transformation>] $\square$
 :::
 
 

--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -30,8 +30,8 @@ Der Stoff dieses Kapitels orientiert sich an @mcelreath2020, Kap. 4.4 sowie @gel
 
 Frischen Sie Ihr Wissen in den Grundlagen der einfachen und multiplen Regression (inkl. Interaktionseffekte) auf. Dazu sind z. B. folgende Literaturstellen geeignet.
 
-- [Statistik1, Kap. "Geradenmodelle 1"](https://statistik1.netlify.app/080-regression1)^[<https://statistik1.netlify.app/080-regression1>]
-- [Statistik1, Kap. "Geradenmodelle 2"](https://statistik1.netlify.app/090-regression2)^[<https://statistik1.netlify.app/090-regression2>]
+- [Statistik1, Kap. "Geradenmodelle 1"](https://sebastiansauer.github.io/statistik1/080-regression1)^[<https://sebastiansauer.github.io/statistik1/080-regression1>]
+- [Statistik1, Kap. "Geradenmodelle 2"](https://sebastiansauer.github.io/statistik1/090-regression2)^[<https://sebastiansauer.github.io/statistik1/090-regression2>]
 
 
 
@@ -107,13 +107,13 @@ data("penguins", package = "palmerpenguins")
 
 :::{#exm-skalenniveaus}
 ### Was waren noch mal die Skalenniveaus?
-Um Forschungsfragen zu klassifizieren, müssen Sie wissen, was die Skalenniveaus der beteiligten AV und der UV(s) sind.^[Hier ist eine kurze Erklärung dazu: https://statistik1.netlify.app/010-rahmen#sec-arten-variablen]
+Um Forschungsfragen zu klassifizieren, müssen Sie wissen, was die Skalenniveaus der beteiligten AV und der UV(s) sind.^[Hier ist eine kurze Erklärung dazu: https://sebastiansauer.github.io/statistik1/010-rahmen#sec-arten-variablen]
 $\square$
 :::
 
 :::{#exm-interaktion}
 ### Was war noch einmal die Interaktion?
-Erklären Sie die Grundkonzepte der Interaktion (hier synonym: Moderation) im Rahmen einer Regressionsanalyse!^[Hier finden Sie eine kurze Erklärung zur Interaktion: https://statistik1.netlify.app/090-regression2#interaktion] $\square$
+Erklären Sie die Grundkonzepte der Interaktion (hier synonym: Moderation) im Rahmen einer Regressionsanalyse!^[Hier finden Sie eine kurze Erklärung zur Interaktion: https://sebastiansauer.github.io/statistik1/090-regression2#interaktion] $\square$
 :::
 
 
@@ -1053,7 +1053,7 @@ Ob die Effekte stärker als "praktisch Null" sind, kann mittels des ROPE-Verfahr
 
 
 
-Unter *Zentrieren* (to *c*enter) versteht man das Bilden der Differenz eines Messwerts zu seinem Mittelwert.^[Vgl. Abschnitt "UV zentrieren" (<https://statistik1.netlify.app/090-regression2.html#uv-zentrieren>) im Kursbuch Statistik1 (<https://statistik1.netlify.app/>).]
+Unter *Zentrieren* (to *c*enter) versteht man das Bilden der Differenz eines Messwerts zu seinem Mittelwert.^[Vgl. Abschnitt "UV zentrieren" (<https://sebastiansauer.github.io/statistik1/090-regression2.html#uv-zentrieren>) im Kursbuch Statistik1 (<https://sebastiansauer.github.io/statistik1/>).]
 Zentrierte Werte geben also an, wie weit ein Messwert vom mittleren (typischen) Messwert entfernt ist.
 Mit zentrierten Werten ist eine Regression einfacher zu interpretieren.
 Hier zentrieren wir (nur) `mom_iq`; 

--- a/1050-Schaetzen-Testen.qmd
+++ b/1050-Schaetzen-Testen.qmd
@@ -30,7 +30,7 @@ Der Stoff dieses Kapitels orientiert sich an [@kruschke2018].
 
 Lesen Sie zur Vorbereitung folgende Literatur:
 
-- [Statistik1, Kap. "Geradenmodelle 2"](https://statistik1.netlify.app/090-regression2)^[<https://statistik1.netlify.app/090-regression2>]
+- [Statistik1, Kap. "Geradenmodelle 2"](https://sebastiansauer.github.io/statistik1/090-regression2)^[<https://sebastiansauer.github.io/statistik1/090-regression2>]
 
 
 

--- a/slides/index.qmd
+++ b/slides/index.qmd
@@ -109,7 +109,7 @@ Siehe Tabelle im Haupttext (Kapitel "Einführung") für den zeitlichen Ablauf de
 - Grundlegende Kenntnis der Regressionsanalyse
 
 ::: {.fragment}
-Vermittelt z. B. im Online-Buch ["Statistik1"](https://statistik1.netlify.app/) — die Kapitel bauen aufeinander auf.
+Vermittelt z. B. im Online-Buch ["Statistik1"](https://sebastiansauer.github.io/statistik1/) — die Kapitel bauen aufeinander auf.
 :::
 
 ## Lernhilfen & Software


### PR DESCRIPTION
## Summary
- Ersetzt alle Vorkommen von `https://statistik1.netlify.app` durch `https://sebastiansauer.github.io/statistik1` in 12 Kapiteldateien
- Betroffen: 0100-orga.qmd, 0200-zielarten.qmd, 0250-inferenz.qmd, 0400-Verteilungen.qmd, 0500-Globusversuch.qmd, 0600-Post.qmd, 0700-ppv.qmd, 0800-gauss.qmd, 0900-lineare-modelle.qmd, 1000-metrische-AV.qmd, 1050-Schaetzen-Testen.qmd, slides/index.qmd

## Test plan
- [ ] `quarto render` prüfen, dass Links korrekt aufgelöst werden

https://claude.ai/code/session_01UjxcdodgJXpD9JxXqKsLh6