### PR TITLE
Abstand der Wahrscheinlichkeits-Labels in fig-2dice-prob verringern

### DIFF
--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -1245,10 +1245,10 @@ twodice <- tibble(
   p = probabilities) |> 
   mutate(p_cum = cumsum(p))
 
-p_twodice <- 
-  ggplot(twodice, aes(x = Augensumme, y = p)) + 
+p_twodice <-
+  ggplot(twodice, aes(x = Augensumme, y = p)) +
   geom_col() +
-  geom_label(aes(y = p, label = round(p, 2))) +
+  geom_label(aes(y = p, label = round(p, 2)), vjust = 0) +
   scale_x_continuous(breaks = 1:12)
 ```
 


### PR DESCRIPTION
## Summary
- Abbildung 4.25 (Wahrscheinlichkeitsverteilung der Zufallsvariable „Augenzahl im zweifachen Würfelwurf"): Die Labels über den Balken standen zu hoch (`geom_label()` zentrierte standardmäßig auf `y = p`).
- Fix: `vjust = 0` gesetzt, sodass die Labels direkt über der Balkenoberkante sitzen statt mit großem vertikalen Abstand zu schweben.

## Test plan
- [x] `quarto render 0300-Wskt.qmd` fehlerfrei ausgeführt
- [x] Neu erzeugtes PNG (`fig-2dice-prob-1.png`) geprüft: Labels sitzen jetzt knapp über den Balken