### PR TITLE
Fehlerhafte Callout-Fenced-Divs korrigieren

### DIFF
--- a/0100-orga.qmd
+++ b/0100-orga.qmd
@@ -247,12 +247,13 @@ Alternativ steht in jedem Kapitel ein Foliensatz zur Verfügung (in HTML-Version
 
 :::: {layout="[ 80, 20 ]"}
 ::: {#first-column}
+
 Schauen Sie sich mal den YouTube-Kanal *sebastiansauerstatistics* an 
 und dann z. B. die [Playlist "R"](https://www.youtube.com/playlist?list=PLRR4REmBgpIEaIyeNBgNGPgmhQJ_T1y8_).
 Dort finden Sie  *Videos zum Thema dieses Buches*.
 :::
 
-::: {#second-column valign="top"}
+::: {#second-column}
 
 ```{r}
 #| echo: false
@@ -260,7 +261,7 @@ Dort finden Sie  *Videos zum Thema dieses Buches*.
 #| fig-align: center
 qr <- qrcode::qr_code("https://www.youtube.com/playlist?list=PLRR4REmBgpIEaIyeNBgNGPgmhQJ_T1y8_")
 
-par(mar = c(0, 0, 0, 0))
+#par(mar = c(0, 0, 0, 0))
 plot(qr)
 ```
 :::

--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -447,7 +447,7 @@ plot(dag_studie_a)
 Betrachtung der Gesamtdaten zeigt in diesem Fall einen *konfundierten* Effekt: Geschlecht konfundiert den Zusammenhang von Medikament und Heilung.
 
 
-:::callout-important
+::: {.callout-important}
 Aufteilen in Teilgruppen (Männer bzw. Frauen) ist also in diesem Fall der korrekte, richtige Weg.
 Achtung: Das Stratifizieren ist nicht immer und nicht automatisch die richtige Lösung.
 Stratifizieren bedeutet,
@@ -540,7 +540,7 @@ Betrachtung der Teildaten zeigt nur den toxischen Effekt des Medikaments, nicht 
 
 
 
-:::callout-important
+::: {.callout-important}
 Betrachtung der Gesamtdaten zeigt in diesem Fall den wahren, kausalen Effekt. 
 Stratifizieren wäre falsch, da dann nur der toxische Effekt, aber nicht der heilsame Effekt sichtbar wäre.
 :::
@@ -579,7 +579,7 @@ Kausalinferenz 📚 plus Datenanalyse 📊 erlaubt Kausalschlüsse. 📚➕📊 
 
 
 
-:::callout-important
+::: {.callout-important}
 Für Entscheidungen ("Was soll ich tun?") braucht man kausales Wissen.
 Kausales Wissen basiert auf einer Theorie (Kausalmodell) plus Daten.
 :::
@@ -606,7 +606,7 @@ Beispiele:
 Populationsinferenz beantwortet also Fragen wie "Wie sicher können wir sein?" bzw. "Ist der gefundene Effekt echt (in der Population) oder nur Stichprobenrauschen?".
 Dazu verwendet man Werkzeuge wie Konfidenzintervalle, Signifikanztests oder -- in diesem Buch im Vordergrund -- Bayes-Statistik.
 
-:::callout-important
+::: {.callout-important}
 Populationsinferenz sagt nichts über Ursache und Wirkung aus.
 Ein statistisch gesicherter Zusammenhang in der Population kann trotzdem konfundiert sein.
 :::
@@ -801,13 +801,13 @@ Muss man aber nicht -- man kann stattdessen die Regression benutzen.
 
 
 
-:::callout-note
+::: {.callout-note}
 Es ist meist einfacher und nützlicher, die Regression zu verwenden, anstelle der Vielzahl von anderen Verfahren (die zumeist Spezialfälle der Regression sind). In diesem Kurs werden wir für alle Fragestellungen die Regression verwenden.^[Wie Jonas Kristoffer Lindeløv (<https://lindeloev.github.io/tests-as-linear/>) uns erklärt, sind viele statistische Verfahren, wie der sog. t-Test Spezialfälle der Regression.] $\square$
 :::
 
 :::: {.content-visible when-format="html"}
 
-:::callout-note
+::: {.callout-note}
 Regression + Inferenz = 💖
 :::
 ::::
@@ -921,7 +921,7 @@ F) Keine der oben genannten $\square$
 
 
 
-:::callout-important
+::: {.callout-important}
 [Kontinuierliches Lernen](https://imgflip.com/i/77wn7m)^[<https://imgflip.com/i/77wn7m>] ist der Schlüssel zum Erfolg.
 :::
 

--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -930,7 +930,7 @@ Wenn Sie an einer (nicht prüfungsrelevanten) Vertiefung interessiert sind, lese
 
 ## Aufgaben
 
-Schauen Sie sich die Aufgaben mit dem Tag *inference* auf dem [Datenwerk](https://datenwerk.netlify.app/#category=inference) an.
+<!-- Schauen Sie sich die Aufgaben mit dem Tag *inference* auf dem [Datenwerk](https://datenwerk.netlify.app/#category=inference) an.
 
 ### Papier-und-Bleistift-Aufgaben
 
@@ -941,7 +941,7 @@ Schauen Sie sich die Aufgaben mit dem Tag *inference* auf dem [Datenwerk](https:
 1. [mariokart_desk-inf-mod](https://sebastiansauer.github.io/datenwerk/posts/mariokart_desk-inf-mod/index.html)
 
 
-
+ -->
 
 
 ::: {.content-visible when-format="html"}

--- a/0250-inferenz.qmd
+++ b/0250-inferenz.qmd
@@ -120,7 +120,7 @@ Messerscharf schließen wir:
 In der Grundgesamtheit ist der Anteil der R-Fans auch 42 %, $\pi=0.42$.
 
 
-:::callout-note
+::: {.callout-note}
 Wir verwenden lateinische Buchstaben (p), um Kennzahlen einer Stichprobe zu benennen, und griechische ($\pi$) für Populationen. $\square$
 :::
 
@@ -201,7 +201,7 @@ In der angewandten Forschung und im praktischen Leben interessieren häufig Frag
 Da bekanntlich (fast) keine Aussagen sicher sind, spielt *Wahrscheinlichkeit* 
 eine wichtige Rolle in den Forschungsfragen bzw. in deren Antworten.
 
-:::callout-note
+::: {.callout-note}
 Wahrscheinlichkeit wird oft mit *Pr* oder *p* abgekürzt, für engl. *probability*. $\square$
 :::
 
@@ -271,7 +271,7 @@ Aus diesem begrenzten Wissen resultiert notwendig Ungewissheit über die gesamte
 
 
 
-:::callout-important
+::: {.callout-important}
 Nichts Genaues weiß man nicht: 
 Schließt man von einem Teil auf das Ganze, so geschieht das unter Unsicherheit. 
 Man spricht von *Ungewissheit*, da man sich auf die *Unsicherheit des Wissens* über die Genauigkeit des Schließens bezieht.
@@ -472,7 +472,7 @@ Je nachdem, wie es der Zufall (oder sonst wer) will, landen bestimmte Fälle (Fl
 Zumeist unterscheiden sich die Stichproben; 
 theoretisch könnten sie aber auch rein zufällig gleich sein.
 
-:::callout-important
+::: {.callout-important}
 Stichproben-Kennwerte schwanken um den tatsächlichen Wert in der Population herum. $\square$
 :::
 
@@ -579,7 +579,7 @@ Angenommen, jemand sagt, dass sie den Anteil der R-Fans (in der Population) auf 
 lässt aber offen wie *sicher* (präzise) die Schätzung (der Modellparameter) ist.
 Wir wissen also nicht, ob z. B. 2 % oder 82 % noch erwartbar sind. Oder ob man im Gegenteil mit hoher Sicherheit sagen kann, die Schätzung schließt sogar 41 % oder 43 % aus.
 
-:::callout-important
+::: {.callout-important}
 Schließt man auf eine Population, schätzt also die Modellparameter, 
 so sollte stets die (Un-)Genauigkeit der Schätzung, also die Ungewissheit des Modells, angegeben sein. $\square$
 :::

--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -85,7 +85,7 @@ Lesen Sie zur Begleitung dieses Kapitels @bourier2011, Kap. 2-4.
 Der Stoff dieses Kapitels deckt sich in Teilen mit @bourier2011, Kap. 2-4.
 Weitere Übungsaufgaben finden Sie im dazugehörigen Übungsbuch, @bourier2022.
 
-:::callout-note
+::: {.callout-note}
 In Ihrer [Hochschul-Bibliothek kann das Buch als Ebook verfügbar](https://fantp20.bib-bvb.de/TouchPoint/singleHit.do?methodToCall=showHit&curPos=3&identifier=2_SOLR_SERVER_1157422278)^[<https://fantp20.bib-bvb.de/TouchPoint/singleHit.do?methodToCall=showHit&curPos=3&identifier=2_SOLR_SERVER_1157422278>] sein. 
 Prüfen Sie, ob Ihr Dozent Ihnen weitere Hilfen im [geschützten Bereich (Moodle)](https://moodle.hs-ansbach.de/mod/resource/view.php?id=136047)^[<https://moodle.hs-ansbach.de/mod/resource/view.php?id=136047>] eingestellt hat. $\square$
 :::
@@ -157,7 +157,7 @@ In jedem dieser Fälle sind die möglichen Ergebnisse nicht im Voraus bekannt un
 :::
 
 
-:::callout-caution
+::: {.callout-caution}
 Zufall heißt nicht, dass ein Vorgang keine Ursachen hätte. 
 So gehorcht der Fall einer Münze komplett den Gesetzen der Gravitation. 
 Würden wir diese Gesetze und die Ausgangsbedingungen (Luftdruck, Fallhöhe, Oberflächenbeschaffenheit, Gewichtsverteilungen, ...) exakt kennen, könnten wir theoretisch sehr genaue Vorhersagen machen. 
@@ -212,9 +212,8 @@ Die Wahrscheinlichkeitsrechnung baut auf der Mengenlehre auf, daher wird die Not
 ![Ein (sechsseitiger) Würfel, Bildquelle: Peter Steinberg, Wikipedia, CC-BY-SA 3.0](img/120px-Hexahedron-slowturn.gif){#fig-wuerfel width=10%}
 :::
 
+
 ::: {.content-visible unless-format="html"}
-
-
 ![Ein (sechsseitiger) Würfel](img/wuerfel_3d_isometrisch.svg){width=33%}
 :::
 
@@ -553,7 +552,7 @@ Aber wenn die Person relevante Symptome $S$ hat, gilt: $Pr(\text{K} \mid \text{S
 :::
 
 
-:::callout-note
+::: {.callout-note}
 Sagt jemand: "Die Wahrscheinlichkeit von A ist x %", frag immer: "gegeben welcher Annahmen, welcher Evidenz?"
 :::
 
@@ -762,7 +761,7 @@ Da wir Ereignisse als Mengen auffassen, verwenden wir im Folgenden die beiden Be
 Dabei nutzen wir u.a. Venn-Diagramme.
 Venn-Diagramme eigenen sich, um typische Operationen (Relationen) auf Mengen zu visualisieren. Die folgenden Venn-Diagramme stammen von [Wikipedia](https://en.wikipedia.org/wiki/Venn_diagram)^[<https://en.wikipedia.org/wiki/Venn_diagram>].
 
-:::callout-note
+::: {.callout-note}
 ### Wozu sind die Venn-Diagramme gut? Warum soll ich die lernen?
 Venn-Diagramme zeigen Kreise und ihre überlappenden Teile;
 daraus lassen sich Rückschlüsse auf Rechenregeln für Wahrscheinlichkeiten ableiten.
@@ -875,7 +874,7 @@ intersect(A, B)
 
 
 
-:::callout-note
+::: {.callout-note}
 #### Eselsbrücke zur Vereinigungs- und Schnittmenge
 
 Das Zeichen für eine Vereinigung zweier Mengen "$\cup$" kann man leicht mit dem Zeichen für einen Schnitt zweier Mengen "$\cap$" verwechseln;
@@ -990,7 +989,7 @@ setdiff(A, B)
 🤯 Von der Menge $A$ die Menge $B$ abzuziehen, ist etwas anderes, als von $B$ die Menge $A$ abzuziehen.
 
 
-:::callout-caution
+::: {.callout-caution}
 $A \setminus B \ne B \setminus A$.
 :::
 

--- a/0350-wskt2.qmd
+++ b/0350-wskt2.qmd
@@ -69,7 +69,7 @@ Lesen Sie zur Begleitung dieses Kapitels @bourier2011, Kap. 2-4.
 Der Stoff dieses Kapitels deckt sich (weitgehend) mit @bourier2011, Kap. 2-4. 
 Weitere Übungsaufgaben finden Sie im dazugehörigen Übungsbuch, @bourier2022.
 
-:::callout-note
+::: {.callout-note}
 In Ihrer [Hochschul-Bibliothek kann das Buch als Ebook verfügbar](https://fantp20.bib-bvb.de/TouchPoint/singleHit.do?methodToCall=showHit&curPos=3&identifier=2_SOLR_SERVER_1157422278)^[<https://fantp20.bib-bvb.de/TouchPoint/singleHit.do?methodToCall=showHit&curPos=3&identifier=2_SOLR_SERVER_1157422278>] sein. 
 Prüfen Sie, ob Ihr Dozent Ihnen weitere Hilfen im [geschützten Bereich (Moodle)](https://moodle.hs-ansbach.de/mod/resource/view.php?id=136047)^[<https://moodle.hs-ansbach.de/mod/resource/view.php?id=136047>] eingestellt hat. $\square$
 :::

--- a/0600-Post.qmd
+++ b/0600-Post.qmd
@@ -662,7 +662,7 @@ So, jetzt befragen wir die Post-Verteilung.
 :::
 
 
-:::callout-important
+::: {.callout-important}
 Die Post-Verteilung ist das zentrale Ergebnis einer Bayes-Analyse.
 Wir können viele nützliche Fragen an sie stellen.
 :::
@@ -1422,7 +1422,7 @@ Anstelle von Streuungsparametern ist es aber üblicher, ein HDI oder PI für den
 
 
 
-:::callout-important
+::: {.callout-important}
 Alles Wasser oder was?
 Im Beispiel dieses Kapitels haben wir uns gefragt, was wohl der Wasseranteil auf dem Planeten Erde ist.
 Halten Sie sich klar vor Augen:

--- a/0700-ppv.qmd
+++ b/0700-ppv.qmd
@@ -241,7 +241,7 @@ Wir finden eine recht hohe Wahrscheinlichkeit für eine "massive" Manipulation d
 :::
 
 
-:::callout-important
+::: {.callout-important}
 Ist es nicht einfach und schön, wie wir mit Hilfe des Stichprobenziehens allerlei Forschungsfragen beantworten können?
 Eine Post-Verteilung aus Stichproben erlaubt uns, viele Fragen mit einfachen Methoden,
 nämlich schlichtes Zählen, zu beantworten.
@@ -256,7 +256,7 @@ Wir sind indifferent gegenüber dem Parameter $\pi$, der Trefferwahrscheinlichke
 
 
 
-:::callout-note
+::: {.callout-note}
 In einem zweiten Versuch könnten wir jetzt unsere Post-Verteilung als Priori-Verteilung 
 nutzen. 
 Das Ergebnis des ersten Versuchs wird dann hergenommen als Ausgangspunkt für 
@@ -292,7 +292,7 @@ Damit könnten wir herausfinden, welche Trefferzahlen sich bei verschiedenen Was
 
 Wer gerne bastelt, freut sich darauf. Kritischere Geister^[oder weniger bastelfreundliche] würden den Aufwand bemängeln und die Frage nach dem Zweck der Übung stellen^[bravo!].
 
-:::callout-important
+::: {.callout-important}
 Wenn wir wissen, welche Trefferzahlen laut einem Modell zu erwarten sind,
 können wir die *echten* (beobachteten) Trefferzahlen mit den laut Modell zu erwartenden vergleichen.
 Damit haben wir eine Methode, mit dem wir ein Modell auf Herz und Nieren prüfen können.
@@ -338,7 +338,7 @@ ganz anschaulich gesprochen.
 Natürlich wirft der Computer nicht in Wirklichkeit einen Globus oder eine Münze,
 sondern er zieht aus der Menge `{0,1}` eine Zahl, und wir geben die Wahrscheinlichkeit für jedes der beiden Elemente vor, z. B. jeweils 50 %.^[Übrigens können Computer nicht echten Zufall erzeugen (das kann vermutlich niemand), aber durch gewisse verzwickte Rechnungen sind die Zahlen, die der Computer uns präsentiert, nicht oder kaum vom "Zufall" zu unterscheiden, also z. B. gleichverteilt ohne besondere Muster.].
 
-:::callout-important
+::: {.callout-important}
 Simulationsdaten geben Aufschluss, welche Daten (wie oft Wasser) man bei einem bestimmten Modell, $p,N$, erwarten kann. 
 Münzwürfe -- und analoge Versuche, wie Globuswürfe -- kann man in R mit `rbinom` erstellen (simulieren).
 :::
@@ -433,7 +433,7 @@ draws %>%
 
 Die *Stichprobenverteilung* zeigt, welche Stichprobendaten laut unserem Modell (einem bestimmten Parameterwert) zu erwarten sind. Wir können jetzt prüfen, ob die echten Daten zu den Vorhersagen des Modells passen.
 
-:::callout-note
+::: {.callout-note}
 Die Stichprobenverteilung ist keine empirische Verteilung: Wir führen diese vielen Versuche nicht wirklich durch^[Nur die extremen Bastelfreunde machen das], wir simulieren sie nur am Computer.
 :::
 
@@ -462,7 +462,7 @@ der sehr unwahrscheinliche Wasseranteil^[zumindest laut unserer Post-Verteilung]
 Die resultierende Verteilung -- gemittelte Stichprobenverteilungen über alle Werte der Post-Verteilungen -- nennt man *Posterior-Prädiktiv-Verteilung* (PPV).
 
 
-:::callout-important
+::: {.callout-important}
 
 Die PPV entsteht als gewichteter Mittelwert der Stichprobenverteilungen. Die Gewichte sind die Wahrscheinlichkeiten (bzw. Wahrscheinlichkeitsdichten) der Post-Verteilung.
 :::
@@ -615,7 +615,7 @@ Die PPV unseres Modells zeigt uns (@fig-ppv2), dass wir in künftigen Versuchen 
 Aber ein relativer breiter Bereich an Treffern ist ebenfalls gut laut unserer PPV erwartbar.
 
 
-:::callout-important
+::: {.callout-important}
 Die PPV zeigt, welche Beobachtungen laut unserem Modell häufig und welche selten sind.
 Die PPV zeigt keine Parameterwerte, sondern welche Daten (Beobachtungen, Wasserzahlen) wir in künftigen Versuchen wie häufig erwarten können.
 :::
@@ -685,7 +685,7 @@ Um zu realistischen Vorhersagen zu kommen, möchte man beide Arten von Ungewissh
 Die PPV zeigt, welche Daten das Modell vorhersagt (prädiktiv) und mit welcher Häufigkeit, basierend auf der Post-Verteilung.
 
 
-:::callout-note
+::: {.callout-note}
 Der Unterschied zwischen der Post-Verteilung und der PPV ist erstmal,
 dass die PPV *Ausprägungen* in ihrer Wahrscheinlichkeit bemisst,
 also z. B. wie wahrscheinlich 4 von 9 Wassertreffern sind.

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -458,7 +458,7 @@ dass der Achsenabschnitt eine sinnvolle Aussage macht.
 Zum Glück geht das leicht: Wir zentrieren den Prädiktor (Gewicht)!
 
 
-:::callout-important
+::: {.callout-important}
 Durch Zentrieren kann man die Ergebnisse einer Regression einfacher interpretieren.
 :::
 
@@ -711,7 +711,7 @@ m_kung_starkes_beta1 <-
 ```
 
 
-:::callout-note
+::: {.callout-note}
 Mit `seed` kann man die Zufallszahlen fixieren,
 so dass jedes Mal die gleichen Werte resultieren.
 So ist die Nachprüfbarkeit der Ergebnisse ("Reproduzierbarkeit") sichergestellt^[oder zumindest *besser* sichergestellt].
@@ -949,7 +949,7 @@ get_sigma(m_kung_starkes_beta1)
 Diese Frage wird durch die Ungewissheitsintervalle in der Ausgabe beantwortet.
 
 
-:::callout-note
+::: {.callout-note}
 An einigen Stellen wird empfohlen, anstelle eines (gebräuchlichen) 95 %-Intervalls 
 auf ein 90 %- oder 89 %-Intervall auszuweichen, aufgrund der besseren numerischen Stabilität.
 :::
@@ -1091,7 +1091,7 @@ estimate_expectation(m_kung_starkes_beta1, by = "weight_c") |>  # Regressionsger
 
 ### Fragen zu Quantilen des Achsenabschnitts 
 
-:::callout-note
+::: {.callout-note}
 Zur Erinnerung: Bei einem zentrierten Prädiktor misst der Achsenabschnitt die mittlere Größe^[$\mu$].
 :::
 

--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -913,7 +913,7 @@ Sind die Regressionsgeraden nicht parallel, so spricht man von einer *Interaktio
 (synonym: Interaktionseffekt, Moderation).
 Fügen wir also im nächsten Modell, `m10.4` einen Interaktionseffekt hinzu.
 
-:::callout-important
+::: {.callout-important}
 Liegt eine Interaktion vor, so unterscheidet sich die Steigung der Geraden in den Gruppen.
 Liegt keine Interaktion vor, so sind die Geraden parallel. $\square$
 :::
@@ -1193,7 +1193,7 @@ parameters(m10.5, ci_method = "hdi") |>
 
 
 
-:::callout-important
+::: {.callout-important}
 Das Modell hat mittels @fig-yg mutig Kausalaussagen postuliert. Das ist zwar schön, bedarf aber einer Begründung mit Rückgriff auf die Literatur (was hier nicht getan wurde). Ohne eine Begründung ist die Behauptung der Kausalaussage nicht zu verteidigen.
 :::
 
@@ -1786,7 +1786,7 @@ parameters(m10.9) |>
 
 
 
-:::callout-important
+::: {.callout-important}
 Die Regressionsgewichte unterscheiden sich (potenziell) von denen der jeweiligen univariaten Regressionen.
 :::
 
@@ -2205,7 +2205,7 @@ Hingegen zeigt das Modell, dass das Alter der Mutter statistisch eher keine Roll
 
 
 
-:::callout-important
+::: {.callout-important}
 Hier wird von einem "statistischen Effekt" gesprochen, um klar zu machen, 
 dass es sich lediglich um assoziative Zusammenhänge, 
 und nicht um kausale Zusammenhänge, handelt.
@@ -2579,7 +2579,7 @@ lm(mpg ~ hp + cyl, data = mtcars) |> coef()
 ```
 
 
-:::callout-important
+::: {.callout-important}
 Wenn auch die Ergebnisse eines frequentistischen und eines Bayes-Modells numerisch ähnlich sein können,
 so ist doch die Interpretation grundverschieden. 
 Bayesmodelle erlauben Wahrscheinlichkeitsaussagen zu den Parametern, 
@@ -2696,7 +2696,7 @@ if (knitr:::is_html_output()) {
 
 
 
-:::callout-important
+::: {.callout-important}
 Kontinuierliches Lernen ist der Schlüssel zum Erfolg.
 :::
 

--- a/1050-Schaetzen-Testen.qmd
+++ b/1050-Schaetzen-Testen.qmd
@@ -190,7 +190,7 @@ die Hypothese ist abgelehnt, angenommen, oder die Datenlage ist unklar.
 Das unterstützt die Entscheidungsfindung, da es die Komplexität reduziert.
 
 
-:::callout-note
+::: {.callout-note}
 ### Man kann Hypothesen nicht bestätigen
 Karl Poppers These, dass man Hypothesen nicht bestätigen (verifizieren) kann,
 hatte großen Einfluss auf die Wissenschaftstheorie (und Epistemologie allgemein) ausgeübt [@popper2013].
@@ -542,7 +542,7 @@ Der ROPE-Grenzwert wurde hier per Voreinstellung auf 80 g Unterschied festgele
 
 
 
-:::callout-note
+::: {.callout-note}
 Die angegebenen Prozentwerte beziehen sich nicht auf die 100 % der Post-Verteilung,
 sondern (in der Voreinstellung) auf das 95 %-ETI. Dabei werden 10 % der Streuung 
 der AV als Intervallgrenzen des ROPE angenommen,

--- a/1150-konfundierung.qmd
+++ b/1150-konfundierung.qmd
@@ -192,7 +192,7 @@ plot(dag_studie_a)
 Betrachtung der Gesamtdaten zeigt in diesem Fall einen *konfundierten* Effekt: Geschlecht konfundiert den Zusammenhang von Medikament und Heilung.
 
 
-:::callout-important
+::: {.callout-important}
 Betrachtung der Teildaten (d. h. stratifiziert pro Gruppe) zeigt in diesem Fall den wahren, kausalen Effekt. 
 Stratifizieren ist also in diesem Fall der korrekte, richtige Weg.
 Achtung: Das Stratifizieren ist nicht immer und nicht automatisch die richtige Lösung.
@@ -285,7 +285,7 @@ Betrachtung der Teildaten zeigt nur den toxischen Effekt des Medikaments, nicht 
 
 
 
-:::callout-important
+::: {.callout-important}
 Betrachtung der Gesamtdaten zeigt in diesem Fall den wahren, kausalen Effekt. 
 Stratifizieren wäre falsch, da dann nur der toxische Effekt, aber nicht der heilsame Effekt sichtbar wäre.
 :::
@@ -324,7 +324,7 @@ Datenanalyse plus Kausalinferenz erlaubt Kausalschlüsse. 📚➕📊  🟰  �
 
 
 
-:::callout-important
+::: {.callout-important}
 Für Entscheidungen ("Was soll ich tun?") braucht man kausales Wissen.
 Kausales Wissen basiert auf einer Theorie (Kausalmodell) plus Daten.
 :::
@@ -652,7 +652,7 @@ Don 🧑:  "Volltreffer! Jetzt verdien ich 100 Tausend mehr! Ich bin der Größt
 
 
 
-:::callout-note
+::: {.callout-note}
 Zur Erinnerung: "4e+05" ist die Kurzform der wissenschaftlichen Schreibweise und bedeutet: $4 \cdot 100000 = 4\cdot10^5 = 400000$
 :::
 
@@ -900,7 +900,7 @@ Don 🧑:  "Wozu ist sie dann gut?!"
 
 
 
-:::callout-important
+::: {.callout-important}
 In Beobachtungsstudien hilft nur ein (korrektes) Kausalmodell. 
 Ohne Kausalmodell ist es *nutzlos*, die Regressionskoeffizienten (oder eine andere Statistik) zur Erklärung der Ursachen heranzuziehen:
 Die Regressionskoeffizienten können sich wild ändern, wenn man Prädiktoren hinzufügt oder weglässt. 
@@ -1203,7 +1203,7 @@ Aber diese behauptete Unabhängigkeit findet sich *nicht* in den Daten wieder, s
 Das Kausalmodell `km2` postuliert *keine* Unabhängigkeiten:
 Laut `km2` sind alle Variablen des Modells miteinander assoziiert (korreliert).
 
-:::callout-note
+::: {.callout-note}
 Ein Modell, in dem alle Variablen miteinander korreliert sind,
 nennt man auch *saturiert* oder saturiertes Modell.
 So ein Modell ist empirisch *schwach*.
@@ -1327,7 +1327,7 @@ also mit mehr Variablen.
 
 Etwas verursachen kann man auch (hochtrabend) als "Kausation" bezeichnen.
 
-:::callout-note
+::: {.callout-note}
 Weiß man, was die Wirkung $W$ einer Handlung $H$ (Intervention) ist,  so hat man $H$ als Ursache von $W$ erkannt [@mcelreath2020]. $\square$
 :::
   
@@ -1432,7 +1432,7 @@ knitr::include_graphics("img/correlation_550.png")
 
 
 
-:::callout-important
+::: {.callout-important}
 Korrelation ungleich Kausation! Korrelation *kann* bedeuten, dass eine Kausation vorliegt, aber es muss auch nicht sein, dass Kausation vorliegt.
 Liegt Korrelation ohne Kausation vor, so spricht man von einer *Scheinkorrelation*.
 Um Scheinkorrelation von echter Assoziation (auf Basis von Kausation) abzugrenzen,

--- a/1180-kausalatome.qmd
+++ b/1180-kausalatome.qmd
@@ -457,7 +457,7 @@ Durch Stratifizieren wird eine Stichprobe in (homogene) Untergruppen unterteilt 
 Nur durch das Stratifizieren (Aufteilen in Subgruppen, Kontrollieren, Adjustieren) tritt die Scheinkorrelation auf, s. @fig-eignung-strat.
 
 
-:::callout-note
+::: {.callout-note}
 *Ohne* Stratifizierung tritt *keine* Scheinkorrelation auf.
 *Mit* Stratifizierung tritt Scheinkorrelation auf.
 :::
@@ -516,7 +516,7 @@ Wildes Kontrollieren einer Variablen -- Aufnehmen in die Regression -- kann gena
 *Nur* Kenntnis des DAGs verrät die richtige Entscheidung: ob man eine Variable kontrollieren muss oder es nicht darf.
 
 
-:::callout-note
+::: {.callout-note}
 Nimmt man eine Variable als zweiten Prädiktor auf,
 so "kontrolliert" man diese Variable. Das Regressionsgewicht des ersten Prädiktors wird "bereinigt" 
 um den Einfluss des zweiten Prädiktors; insofern ist der zweite Prädiktor dann "kontrolliert".

--- a/1200-abschluss.qmd
+++ b/1200-abschluss.qmd
@@ -164,7 +164,7 @@ $F(0)=1/2$, die Wahrscheinlichkeit beträgt hier 50 %, dass $x$ nicht größer
 
 Berechnen wir ein einfaches Interaktionsmodell: `mpg ~ hp*vs`.
 
-:::callout-note
+::: {.callout-note}
 Zur Erinnerung: `mpg ~ hp*vs` ist synonym zu (aber kürzer als) `mpg ~ hp + vs + hp:vs`.
 :::
 

--- a/_backup.qmd
+++ b/_backup.qmd
@@ -113,7 +113,7 @@ Dieser Golem liefert uns Stichproben aus der Post-Verteilung zurück.
 Lernen wir jetz also, wie man mit solchen Stichproben umgeht.
 
 
-:::callout-important
+::: {.callout-important}
 Die Post-Verteilung in Stichprobenform ist viel einfach zu handbaben als das direkte Arbeiten mit Wahrscheinlichkeiten. Daher sind viele R-Funktionen für Bayes auf Stichproben eingestellt.
 :::
 
@@ -277,7 +277,7 @@ d_k100 %>%
 So, jetzt befragen wir die Post-Verteilung.
 
 
-:::callout-important
+::: {.callout-important}
 Die Post-Verteilung ist das zentrale Ergebnis einer Bayes-Analyse.
 Wir können viele nützliche Fragen an sie stellen.
 :::
@@ -650,7 +650,7 @@ samples %>%
 Das Modell ist sich also zu 50 % sicher, dass der gesuchte Parameter (der Wasseranteil der Erdoberfläche) sich in diesem Bereich befindet (auf Basis eines HDI).
 
 
-:::callout-note
+::: {.callout-note}
 Das R-Paket `{bayestestR}` ist Teil des Meta-Pakets `{easystats}`.
 Es reicht, wenn Sie `easystats` laden, damit wird bayestestR automatisch geladen.
 :::

--- a/children/ALT-0350-wskt2.qmd
+++ b/children/ALT-0350-wskt2.qmd
@@ -183,7 +183,7 @@ Lesen Sie dazu die angegebene Literatur. $\square$
 Der Stoff dieses Kapitels deckt sich (weitgehend) mit @bourier2011, Kap. 2-4. 
 Weitere Übungsaufgaben finden Sie im dazugehörigen Übungsbuch, @bourier2022.
 
-:::callout-note
+::: {.callout-note}
 In Ihrer [Hochschul-Bibliothek kann das Buch als Ebook verfügbar](https://fantp20.bib-bvb.de/TouchPoint/singleHit.do?methodToCall=showHit&curPos=3&identifier=2_SOLR_SERVER_1157422278) sein. 
 Prüfen Sie, ob Ihr Dozent Ihnen weitere Hilfen im [geschützten Bereich (Moodle)](https://moodle.hs-ansbach.de/mod/resource/view.php?id=136047) eingestellt hat. $\square$
 :::
@@ -215,7 +215,7 @@ Da wir Ereignisse als Mengen auffassen, verwenden wir im Folgenden die beiden Be
 Dabei nutzen wir u. a. Venn-Diagramme.
 Venn-Diagramme eigenen sich, um typische Operationen (Relationen) auf Mengen zu visualisieren. Die folgenden Venn-Diagramme stammen von [Wikipedia (En)](https://en.wikipedia.org/wiki/Venn_diagram).
 
-:::callout-note
+::: {.callout-note}
 ### Wozu sind die Venn-Diagramme gut? Warum soll ich die lernen?
 Venn-Diagramme zeigen Kreise und ihre überlappenden Teile;
 daraus lassen sich Rückschlüsse auf Rechenregeln für Wahrscheinlichkeiten ableiten.
@@ -329,7 +329,7 @@ intersect(A, B)
 
 
 
-:::callout-note
+::: {.callout-note}
 #### Eselsbrücke zur Vereinigungs- und Schnittmenge
 
 Das Zeichen für eine Vereinigung zweier Mengen kann man leicht mit dem Zeichen für einen Schnitt zweier Mengen leicht verwechseln; 
@@ -436,7 +436,7 @@ setdiff(A, B)
 setdiff(B, A)
 ```
 
-:::callout-caution
+::: {.callout-caution}
 $A \setminus B \ne B \setminus A$.
 :::
 

--- a/children/Exponentialverteilung.qmd
+++ b/children/Exponentialverteilung.qmd
@@ -253,7 +253,7 @@ gg_exp(r = 1/8) + labs(subtitle = "lambda = 1/8") + theme_modern()
 
 
 
-:::callout-note
+::: {.callout-note}
 Eine "gut passende" oder gar die "richtige" Verteilung zu finden, 
 ist nicht immer einfach, wenn nicht unmöglich.
 Gut beraten ist man mit der Regel, 

--- a/children/def-formallog-wskt.qmd
+++ b/children/def-formallog-wskt.qmd
@@ -73,7 +73,7 @@ Aber wenn die Person relevante Symptome $S$ hat, gilt: $Pr(\text{K} \mid \text{S
 :::
 
 
-:::callout-note
+::: {.callout-note}
 Sagt jemand: "Die Wahrscheinlichkeit von A ist x %", frag immer: "gegeben welcher Annahmen, welcher Evidenz?"
 :::
 

--- a/children/ppv-befragen.qmd
+++ b/children/ppv-befragen.qmd
@@ -16,7 +16,7 @@ nach der Wahrscheinlichkeit *tatsächlicher* Körpergrößen zu fragen --
 und nicht nur nach *mittleren* Körpergrößen anhand der Post-Verteilung.
 
 
-:::callout-important
+::: {.callout-important}
 Die Post-Verteilung macht *nur* Aussagen zur *mittleren* Körpergröße,
 denn das ist was wir modellieren wollten.
 Möchten wir Aussagen zur Wahrscheinlichkeit *tatsächlicher* Größen treffen,

--- a/index.qmd
+++ b/index.qmd
@@ -14,7 +14,7 @@
 
 
 Dieses Buch führt in die Bayes-Statistik ein, mit Schwerpunkt auf Wahrscheinlichkeit, Inferenz und Kausalität. 
-Es baut auf [Statistik1](https://statistik1.netlify.app/)^[<https://statistik1.netlify.app/>] auf: Wer die Grundlagen der Modellierung schon kennt, ist hier richtig. 
+Es baut auf [Statistik1](https://sebastiansauer.github.io/statistik1/)^[<https://sebastiansauer.github.io/statistik1/>] auf: Wer die Grundlagen der Modellierung schon kennt, ist hier richtig. 
 Sie lernen, statistische Unsicherheit zu beziffern -- und zwar so, wie es die Bayes-Statistik erlaubt: einfach, direkt, nachvollziehbar (und ohne *p*-Werte).
 
 Warum noch ein Statistikbuch, obwohl es schon viele gibt? 


### PR DESCRIPTION
## Summary
- `:::callout-note` / `:::callout-caution` / `:::callout-important` (ohne Leerzeichen/Klammern) sind keine gültige Pandoc-Fenced-Div-Syntax und ließen beim PDF-Rendern das zugehörige schließende `:::` als verwaisten String zurück (main.lua-Warnung "The following string was found in the document: :::"). In ~50 Stellen buchweit auf `::: {.callout-x}` korrigiert.
- Enthält außerdem den Commit "fix pdf" (kleine Folgekorrekturen in 0200-zielarten.qmd/index.qmd).

## Test plan
- [ ] `quarto render --to titlepage-pdf` läuft ohne Fehler durch
- [ ] Callout-Boxen erscheinen im PDF wie gewohnt formatiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MHEFJRdcHPA49dgw1H744