### PR TITLE
Tabelle 2.2 (tbl-studie-b): rechten Seitenrand-Überlauf im PDF beheben

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -480,8 +480,12 @@ studie_b <-
 "Gesamt",  "273/350 überlebt (78%)", "289/350 überlebt (83%)"
   )
 
-studie_b |> 
-  gt()
+studie_b |>
+  knitr::kable() |>
+  kableExtra::kable_styling(full_width = FALSE) |>
+  kableExtra::column_spec(1, width = "2.5cm") |>
+  kableExtra::column_spec(2, width = "4.2cm") |>
+  kableExtra::column_spec(3, width = "4.2cm")
 ```
 
 

--- a/1150-konfundierung.qmd
+++ b/1150-konfundierung.qmd
@@ -224,8 +224,12 @@ studie_b <-
 "Gesamt",  "273/350 überlebt (78%)", "289/350 überlebt (83%)"
   )
 
-studie_b |> 
-  gt()
+studie_b |>
+  knitr::kable() |>
+  kableExtra::kable_styling(full_width = FALSE) |>
+  kableExtra::column_spec(1, width = "2.5cm") |>
+  kableExtra::column_spec(2, width = "4.2cm") |>
+  kableExtra::column_spec(3, width = "4.2cm")
 ```
 
 


### PR DESCRIPTION
gt::gt() erzeugte im LaTeX-Export unbrechbare Spalten; die langen Textzellen ("geringer Blutdruck", "234/270 überlebt (87%)" etc.) liefen dadurch bis zu ~52pt über den rechten Textrand hinaus (verifiziert per pdfplumber-Wortkoordinaten gegen die Rand-Baseline benachbarter Seiten, siehe Fix von tbl-wkeit-desk in 0300-Wskt.qmd). Wechsel auf knitr::kable() + kableExtra::column_spec(width=...) (2.5cm/4.2cm/4.2cm) erzeugt p{}-Spalten mit echtem Zeilenumbruch, kein Überlauf mehr (per erneutem PDF-Render + pdfplumber-Check bestätigt). Betrifft beide Vorkommen der Studie-B-Tabelle (0200-zielarten.qmd und 1150-konfundierung.qmd).

Alle anderen gt()-Tabellen im Buch wurden geprüft: tbl-studie-a (identischer Aufbau, aber kürzere Gruppennamen) läuft nicht über (max. Wortkoordinate liegt exakt auf der Rand-Baseline) und bleibt daher unverändert bei gt(); alle übrigen gt()-Tabellen enthalten nur kurze numerische Zellen und sind nicht betroffen.


Claude-Session: https://claude.ai/code/session_01XR8oEbtuNFJ7oCdJAGsdGL