### PR TITLE
parameters()-Tabellenausgaben auf ausgewählte Spalten reduzieren

### DIFF
--- a/0250-inferenz.qmd
+++ b/0250-inferenz.qmd
@@ -609,7 +609,8 @@ Man spricht anstatt von Schätzbereich auch von einem *Konfidenzintervall*.^[Tat
 ```{r}
 #| label: tbl-toni-params
 #| tbl-cap: Punktschätzer und Schätzbereiche für die Modellkoeffizienten von `lm_toni`
-model_parameters(lm_toni) |> 
+model_parameters(lm_toni) |>
+  select(1,2,5,6) |>
   print_md()
 ```
 Unser Modell gibt den 95 %-Schätzbereich für den Achsenabschnitt an, ca. von 36 bis 56 Klausurpunkten.

--- a/0800-gauss.qmd
+++ b/0800-gauss.qmd
@@ -674,9 +674,10 @@ m_kung |>
 
 ```{r}
 #| echo: false
-m_kung |> 
-  parameters() |> 
-  display()
+m_kung |>
+  parameters() |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 Seeing is believing, s. @fig-m_kung-params-intercept.

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -628,7 +628,9 @@ parameters(m_kung_gewicht_c)
 ```{r}
 #| label: tbl-m_kung_gewicht_c_params
 #| tbl-cap: "Parameter von m_kung_gewicht_c"
-parameters(m_kung_gewicht_c) |> display()
+parameters(m_kung_gewicht_c) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 

--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -305,8 +305,10 @@ Mit `parameters(m10.1)` bekommt man die Parameter des Modells, s. @tbl-m101.
 ```{r echo = TRUE}
 #| echo: false
 #| tbl-cap: "Parameter des Modells m10.1 (sigma ist nicht dargestellt, da meistens nicht von hohem Interesse)"
-#| label: tbl-m101 
-display(parameters(m10.1))
+#| label: tbl-m101
+parameters(m10.1) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 
@@ -726,9 +728,10 @@ m10.2 |>
 #| echo: false
 #| tbl-cap: "Parameter des Modells m10.2"
 #| label: tbl-m102
-m10.2 |> 
-  parameters() |> 
-  display()
+m10.2 |>
+  parameters() |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 Setzt man die (Punktschätzer der) Parameter in die allgemeine Regressionsgleichung von `m10.2` ein,
@@ -798,8 +801,9 @@ m10.3 <-
 #| label: tbl-m103
 #| echo: false
 
-parameters(m10.3) |> 
-  display()
+parameters(m10.3) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 
@@ -938,7 +942,9 @@ in das Modell aufgenommen wurde.
 #| echo: false
 #| label: tbl-m104
 #| tbl-cap: "Parameter von m10.4"
-model_parameters(m10.4) |> print(select = "minimal") 
+model_parameters(m10.4) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 Mit `estimate_relation(m10.4) |> plot()` kann man  sich das Modell visualisieren, s. @fig-m104.
@@ -1081,9 +1087,9 @@ coef(m10.5)  # nur die Punktschätzer für die Koeffizienten ausgeben
 #| echo: false
 #| label: tbl-m105-point
 #| tbl-cap: "Punktschätzer von m10.5 (zentrierte UV)"
-parameters(m10.5) |> 
-  select(1,2, 4, 5) |> 
-  display()
+parameters(m10.5) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 
@@ -1170,16 +1176,16 @@ Im Falle symmetrischer Posteriori-Verteilungen (wie hier) kommen beide Arten von
 #| label: tbl-m105
 parameters(m10.5) |>
   select(1,2,4,5) |>
-  display()
+  print_md()
 ```
 
 
 ```{r Thema6-Teil2-11}
 #| tbl-cap: "Parameter von m10.5 und HDIs"
 #| label: tbl-m105-hdi
-parameters(m10.5, ci_method = "hdi") |> 
-  select(1,2,4,5) |> 
-  display()
+parameters(m10.5, ci_method = "hdi") |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 
@@ -1386,10 +1392,10 @@ m10.6 |> parameters()
 #| echo: false
 #| tbl-cap: "Parameter des Modells m10.6; neben dem Achsenabschnitt sind die Effekte der Gruppe Adelie und Chinstrap ausgewiesen"
 #| label: tbl-m106-params
-m10.6 |> 
-  parameters() |> 
-  select(1,2,4,6) |> 
-  display()
+m10.6 |>
+  parameters() |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 
@@ -2107,8 +2113,9 @@ parameters(m10.12)
 
 ```{r m10-11-params}
 #| echo: false
-parameters(m10.12) |> 
-  select(1,2,4,5) |> display()
+parameters(m10.12) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 

--- a/1050-Schaetzen-Testen.qmd
+++ b/1050-Schaetzen-Testen.qmd
@@ -255,7 +255,9 @@ m_penguins_sex <-
 #| echo: false
 #| label: tbl-m-penguins-sex-params
 #| tbl-cap: "Parameterschätzung des Modells m_penguins; der Gewichtsunterschied zwischen den Mittelwerten der Geschlechter beträgt etwa 700 g."
-parameters(m_penguins_sex) |> print_md()
+parameters(m_penguins_sex) |>
+  select(1,2,4,5,6) |>
+  print_md()
 ```
 
 Grob gesagt sind männliche Tiere ca. 500 g bis 800 g schwerer 

--- a/1200-abschluss.qmd
+++ b/1200-abschluss.qmd
@@ -186,7 +186,9 @@ parameters(m2)
 #| echo: false
 #| label: tbl-m2-params
 #| tbl-cap: "Parameter von m2"
-parameters(m2) |> display()
+parameters(m2) |>
+  select(1,2,4,5) |>
+  print_md()
 ```
 
 @tbl-m2-params zeigt die Visualisierung der Parameter von m2.

--- a/children/prior-predictive-distro.qmd
+++ b/children/prior-predictive-distro.qmd
@@ -337,9 +337,10 @@ m43a %>%
 
 ```{r}
 #| echo: false
-m43a %>% 
-  parameters() %>% 
-  display()
+m43a %>%
+  parameters() %>%
+  select(1,2,4,5) %>%
+  print_md()
 ```
 
 


### PR DESCRIPTION
Einheitliches Muster `parameters(modell) |> select(1,2,4,5) |> print_md()` statt `display()`/`print(select=...)` für reine Modellparameter-Tabellen. Ausnahmen: Stellen, an denen der Fließtext explizit pd/Rhat/ESS erklärt oder referenziert (0800-gauss.qmd, 0900-lineare-modelle.qmd), sowie Plot-Aufrufe und programmatische Extraktion bleiben unverändert; bei m_penguins_sex (1050-Schaetzen-Testen.qmd) bleibt die pd-Spalte sichtbar, da der Text sie referenziert. Für das klassische lm-Modell (0250-inferenz.qmd) wird select(1,2,5,6) verwendet, da model_parameters() dort eine zusätzliche SE-Spalte hat.


Claude-Session: https://claude.ai/code/session_01S2iYP2ujua4tv1v6Qhcwdr