### PR TITLE
Fix fenced-div and crossref warnings in lualatex render

### DIFF
--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -214,7 +214,7 @@ Die Wahrscheinlichkeitsrechnung baut auf der Mengenlehre auf, daher wird die Not
 
 
 ::: {.content-visible unless-format="html"}
-![Ein (sechsseitiger) Würfel](img/wuerfel_3d_isometrisch.svg){width=33%}
+![Ein (sechsseitiger) Würfel](img/wuerfel_3d_isometrisch.svg){#fig-wuerfel width=33%}
 :::
 
 

--- a/0500-Globusversuch.qmd
+++ b/0500-Globusversuch.qmd
@@ -39,6 +39,7 @@ Der Stoff dieses Kapitels deckt einen Teil aus @mcelreath2020, Kap. 2, ab. @mcel
 
 
 Lesen Sie zur Vorbereitung in Statistik 1 [@sauer2025] das [Kapitel "Daten Einlesen"](https://sebastiansauer.github.io/statistik1/020-r)^[<https://sebastiansauer.github.io/statistik1/020-r>].
+
 ::: {.content-visible when-format="html"}
 Das Video [Globusversuch](https://www.youtube.com/watch?v=fGlt9Ld4xzk&list=PLRR4REmBgpIGgz2Oe2Z9FcoLYBDnaWatN&index=6) ist hilfreich.
 :::


### PR DESCRIPTION
## Summary
- `0500-Globusversuch.qmd`: fügt die fehlende Leerzeile vor dem `content-visible`-Div ein, damit Pandoc es als Fenced Div erkennt (sonst wurden die `:::`-Strings wortwörtlich in den Text übernommen → Warnung `The following string was found in the document: :::`).
- `0300-Wskt.qmd`: setzt das Label `#fig-wuerfel` zusätzlich auf das PDF-Bild (`unless-format="html"`-Block), da es zuvor nur im `when-format="html"`-Block existierte und beim PDF-Render entfernt wurde → `Unable to resolve crossref @fig-wuerfel`.

Beide Root Causes wurden über einen isolierten `quarto render --to pdf`-Testlauf reproduziert und nach dem Fix verifiziert (keine Warnungen mehr im Log).

## Test plan
- [x] `quarto render 0300-Wskt.qmd --to pdf` ausgeführt, Log auf `WARNING`, `found in the document`, `fig-wuerfel` geprüft — keine Treffer mehr.
- [ ] Vollständiges `quarto render` (ganzes Buch) zur Sicherheit erneut laufen lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ykmHX7iEC5VcdjABwXjHh