### PR TITLE
Abbildung 2.4: Überlebensrate statt reiner Geschlechterverteilung

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -386,7 +386,7 @@ studie_a |>
 
 ```{r}
 #| label: fig-studie-a
-#| fig-cap: "Daten zur Studie A in einem Balkendiagramm"
+#| fig-cap: "Daten zur Studie A in einem Balkendiagramm: Überlebensrate je Geschlecht, mit bzw. ohne Medikament"
 #| echo: false
 
 source("R-Code/kausalstudie1.R")

--- a/R-Code/kausalstudie1.R
+++ b/R-Code/kausalstudie1.R
@@ -2,51 +2,51 @@ library(ggplot2)
 library(scales)
 library(see)
 
-# Daten vorbereiten
+# Daten vorbereiten: pro Medikamentengruppe x Geschlecht x Status ("überlebt"/"nicht überlebt")
+# Zahlen entsprechen Tabelle 2.1 (tbl-studie-a)
 df <- data.frame(
-  Gruppe = c(
-    "Mit Medikament",
-    "Mit Medikament",
-    "Ohne Medikament",
-    "Ohne Medikament"
-  ),
-  Geschlecht = c("Frauen", "Männer", "Frauen", "Männer"),
-  Anzahl = c(263, 87, 80, 270),
-  # SPALTE FÜR DIE ZUSÄTZLICHEN PROZENTE
-  Zusatz_Prozent = c(0.73, 0.93, 0.69, 0.87)
+  Gruppe = rep(c("Mit Medikament", "Mit Medikament", "Ohne Medikament", "Ohne Medikament"), each = 2),
+  Geschlecht = rep(c("Männer", "Frauen", "Männer", "Frauen"), each = 2),
+  Status = rep(c("überlebt", "nicht überlebt"), 4),
+  Anzahl = c(
+    81, 87 - 81,     # Männer, mit Medikament: 81/87 überlebt
+    192, 263 - 192,  # Frauen, mit Medikament: 192/263 überlebt
+    234, 270 - 234,  # Männer, ohne Medikament: 234/270 überlebt
+    55, 80 - 55       # Frauen, ohne Medikament: 55/80 überlebt
+  )
 )
 
-# Prozentwerte innerhalb der Gruppen berechnen (Base R-Methoden)
-df$Summe <- ave(df$Anzahl, df$Gruppe, FUN = sum)
+df$Status <- factor(df$Status, levels = c("nicht überlebt", "überlebt"))
+
+# Anteile innerhalb von Gruppe x Geschlecht berechnen
+df$Summe <- ave(df$Anzahl, df$Gruppe, df$Geschlecht, FUN = sum)
 df$Prozent <- df$Anzahl / df$Summe
-df$pos <- ave(df$Prozent, df$Gruppe, FUN = function(x) cumsum(x) - x / 2)
-df$Symbol <- ifelse(df$Geschlecht == "Frauen", "\u2640", "\u2642")
 
-
-# *** NEUES LABEL MIT HAKEN (TICK MARK) ***
-# Haken: \u2713 (oder "✔")
-df$Label <- paste0(
-  df$Anzahl,
-  " Frauen"
+df$Label <- ifelse(
+  df$Status == "überlebt",
+  paste0(df$Anzahl, "/", df$Summe, "\n(", percent(df$Prozent, accuracy = 1), ")"),
+  ""
 )
 
-
-# Plot
+# Plot: pro Medikamentengruppe (Facette) die Überlebensrate je Geschlecht
 plot_kausalstudie_a <-
-  ggplot(df, aes(x = Gruppe, y = Prozent, fill = Geschlecht)) +
+  ggplot(df, aes(x = Geschlecht, y = Prozent, fill = Status)) +
   geom_bar(stat = "identity", position = "fill") +
   geom_text(
     aes(label = Label),
     color = "white",
     fontface = "bold",
     position = position_stack(0.5),
-    lineheight = 0.8
+    lineheight = 0.8,
+    size = 3.2
   ) +
+  facet_wrap(~Gruppe) +
   scale_y_continuous(labels = scales::percent) +
   scale_fill_okabeito() +
   labs(
     x = "",
     y = "Anteil",
-    title = "Geschlechterverteilung mit/ohne Medikament"
+    fill = "",
+    title = "Überlebensrate nach Geschlecht, mit/ohne Medikament"
   ) +
   theme_minimal()


### PR DESCRIPTION
## Summary
- Abbildung 2.4 (Balkendiagramm zu Studie A) zeigte bisher nur die Geschlechterverteilung innerhalb der Medikamentengruppen, nicht aber die Überlebensrate aus Tabelle 2.1.
- `R-Code/kausalstudie1.R` zeigt jetzt pro Geschlecht × Medikamentengruppe die Überlebensrate (überlebt/nicht überlebt gestapelt), mit den exakten Werten aus Tabelle 2.1 (93%, 87%, 73%, 69%).
- Bildunterschrift entsprechend angepasst.

## Test plan
- [x] Kapitel 0200-zielarten.qmd vollständig gerendert (HTML + PDF), keine Fehler
- [x] Rendertes Bild manuell geprüft: Werte stimmen exakt mit Tabelle 2.1 überein

https://claude.ai/code/session_01QEB8aTgZqnW5aFQTd88A1w