### PR TITLE
Fix: theme_modern statt theme_minimal bei Abb. 5.13 (Produktion/Aussc…

### DIFF
--- a/R-Code/plot_maschine_schrott.R
+++ b/R-Code/plot_maschine_schrott.R
@@ -38,7 +38,7 @@ plot_maschine_schrott_ALT <-
     values = c("Schrott" = "red", "ok" = "grey40"),
     labels = c("Ausschuss", "OK")
   ) +
-  theme_minimal() +
+  see::theme_modern() +
   theme(legend.position = "bottom")
 
 
@@ -83,7 +83,7 @@ plot_maschine_schrott <-
   scale_fill_okabeito(
     labels = c("Ausschuss", "OK")
   ) +
-  theme_minimal() +
+  see::theme_modern() +
   theme(legend.position = "bottom")
 
 


### PR DESCRIPTION
…huss)

Das Diagramm überschrieb die global in _common.R gesetzte theme_modern()-Konvention mit theme_minimal(). Betrifft sowohl das verwendete Balkendiagramm (plot_maschine_schrott) als auch den ungenutzten Mosaicplot (plot_maschine_schrott_ALT).


Claude-Session: https://claude.ai/code/session_01VXjiyWNMRsFagMgsXPPHup