### PR TITLE
Tabelle 5.4 (Titanic/Primzahl) schmaler rendern

### DIFF
--- a/0350-wskt2.qmd
+++ b/0350-wskt2.qmd
@@ -705,8 +705,9 @@ titanic2 |>
   count(Survived, Age_prime) |> 
   group_by(Survived) |> 
   mutate(prop = n/sum(n)) |> 
-  gt::gt() |> 
-  gt::fmt_number(columns = prop, decimals = 2)
+  gt::gt() |>
+  gt::fmt_number(columns = prop, decimals = 2) |>
+  gt::tab_options(table.width = gt::pct(50))
 ```
 
 :::


### PR DESCRIPTION
Die gt-Tabelle nahm die volle Breite ein, obwohl sie nur wenige, schmale Spalten hat. table.width auf 50% begrenzt.


Claude-Session: https://claude.ai/code/session_01Las89iNMVKtjLnVHmSzkDq