### PR TITLE
Emojis in Mathe-Umgebung (Bsp. kalt/Regen) sichtbar machen

### DIFF
--- a/0350-wskt2.qmd
+++ b/0350-wskt2.qmd
@@ -1158,12 +1158,12 @@ wenn's *regnet* ⛈️ mal die Wahrscheinlichkeit von *Regen* ⛈️.
 
 Das Gesagte als Emoji-Gleichung ist in @eq-kalt-regen-emoji dargestellt.
 
-$$Pr(❄️ \text{ und } ⛈️) = P(❄️) \cdot P(⛈️ |❄️ )  =  P(❄️) \cdot P(❄️ |⛈️ )$${#eq-kalt-regen-emoji}
+$$Pr(\text{❄️} \text{ und } \text{⛈️}) = P(\text{❄️}) \cdot P(\text{⛈️} |\text{❄️} )  =  P(\text{❄️}) \cdot P(\text{❄️} |\text{⛈️} )$${#eq-kalt-regen-emoji}
 
 
 Man kann  die "Gleichung drehen"^[Der Multiplikationssatz ist symmetrisch], s. @eq-kalt-regen-emoji2. 
 
-$$Pr(❄️ \text{ und } ⛈️) = P(⛈️ \text{ und } ❄️)$${#eq-kalt-regen-emoji2} $\square$
+$$Pr(\text{❄️} \text{ und } \text{⛈️}) = P(\text{⛈️} \text{ und } \text{❄️})$${#eq-kalt-regen-emoji2} $\square$
 :::
 
 


### PR DESCRIPTION
Der luaotfload-Emoji-Fallback greift nur auf mainfont/sansfont/monofont, nicht auf den separaten Mathe-Font. Dadurch verschwanden die Schneeflocken- und Gewitter-Emojis in den beiden $$-Gleichungen von exm-kaltregen im PDF-Export, obwohl sie im umgebenden Fließtext korrekt gerendert werden. Fix: Emojis in \text{} innerhalb der Mathe-Umgebung wrappen, damit der Fallback greift (per lualatex-Testkompilat verifiziert).


Claude-Session: https://claude.ai/code/session_01GiKvvTvgSR2oPz1Lb8XsN7