### PR TITLE
Rope-Tabellen: Spalten Component/Effects/CI ausblenden

### DIFF
--- a/1050-Schaetzen-Testen.qmd
+++ b/1050-Schaetzen-Testen.qmd
@@ -526,7 +526,9 @@ Den Rope berechnet man mit `rope(model)`, s. @tbl-peng-species-rope.
 #| echo: false
 #| label: tbl-peng-species-rope
 #| tbl-cap: "Der Rope-Bereich für die Stufen der UV (Arten von Pinguinen)"
-rope(m_penguins_species)
+rope(m_penguins_species) |>
+  dplyr::select(-Component, -Effects, -CI) |>
+  print_md()
 ```
 
 Die Faktorstufe `Chinstrap` der UV `species` hat 
@@ -626,8 +628,8 @@ Die ROPE-Grenzen sind in @tbl-rope-species-rope-fine zu sehen.
 #| label: tbl-rope-species-rope-fine
 #| echo: false
 #| tbl-cap: "ROPE-Grenzen für das Modell `m_penguins_species` mit ROPE-Grenzen von 500 g."
-rope(m_penguins_species, range = c(-500, 500), ci = .89, ci_method = "HDI") |> 
-  dplyr::select(-Effects, -Component) |>
+rope(m_penguins_species, range = c(-500, 500), ci = .89, ci_method = "HDI") |>
+  dplyr::select(-Effects, -Component, -CI) |>
   print_md()
 ```
 

--- a/children/faq.qmd
+++ b/children/faq.qmd
@@ -90,7 +90,9 @@ penguins <- read.csv("https://vincentarelbundock.github.io/Rdatasets/csv/palmerp
 
 m1 <- stan_glm(bill_length_mm ~ year, data = penguins, refresh = 0)
 
-rope(m1)
+rope(m1) |>
+  dplyr::select(-Component, -Effects, -CI) |>
+  print_md()
 ```
 
 Hier ist das Modell *mit* z-Transformation:
@@ -103,7 +105,9 @@ p2 <-
 
 m2 <- stan_glm(bill_length_mm ~ year, data = p2, refresh = 0)
 
-rope(m2)
+rope(m2) |>
+  dplyr::select(-Component, -Effects, -CI) |>
+  print_md()
 ```
 
 


### PR DESCRIPTION
## Summary
- In allen `rope()`-Tabellen werden nun `dplyr::select(-Component, -Effects, -CI)` vor `print_md()` angewendet, damit diese drei Spalten nicht mehr angezeigt werden.
- Betrifft: `1050-Schaetzen-Testen.qmd` (@tbl-peng-species-rope, @tbl-rope-species-rope-fine) und `children/faq.qmd` (beide FAQ-Beispiele mit `rope(m1)`/`rope(m2)`).

## Test plan
- [x] Isolierter Test mit `stan_glm`/`rope()`/`select()`/`print_md()` bestätigt korrekte Ausgabe ohne Component/Effects/CI-Spalten.
- [ ] Volles `quarto render` der betroffenen Kapitel zur Sichtprüfung (nicht ausgeführt wegen langer Stan-Kompilierzeit im Worktree ohne Cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hurt2cBPrceNLBbAZNYuYe