### PR TITLE
Klappentext als description in _quarto.yml aufnehmen

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,8 +8,16 @@ engine: knitr
 
 lang: de
 citation: true
-description: |
-  Einführung in die Bayes-Statistik mit R
+description: >-
+  Start:Bayes! ist die erste deutschsprachige Einführung in die Bayes-Statistik, die
+  anwendungsnah, mit modernen Werkzeugen (R) und mit mehr Lockerheit als oft üblich
+  vermittelt wird. Statt p-Werten steht eine Idee im Zentrum, die näher am gesunden
+  Menschenverstand ist: Wir starten mit einer Annahme, sammeln Daten und aktualisieren
+  unser Wissen entsprechend. Das Buch richtet sich an alle, die Bayes-Modelle nicht nur
+  verstehen, sondern selbst berechnen und interpretieren wollen. Der Aufbau folgt der
+  Logik der Sache: von Wahrscheinlichkeit und Verteilungen über den Kern der
+  Bayes-Statistik am Beispiel des Globus-Versuchs bis zu linearen Modellen und
+  Kausalität.
 license: "MIT"
 keywords:
   - Statistik
@@ -44,7 +52,16 @@ book:
   author:
     - name: Sebastian Sauer
       orcid: 0000-0003-1515-8348
-  description: "Einführung in die Bayes-Statistik mit R"
+  description: >-
+    Start:Bayes! ist die erste deutschsprachige Einführung in die Bayes-Statistik, die
+    anwendungsnah, mit modernen Werkzeugen (R) und mit mehr Lockerheit als oft üblich
+    vermittelt wird. Statt p-Werten steht eine Idee im Zentrum, die näher am gesunden
+    Menschenverstand ist: Wir starten mit einer Annahme, sammeln Daten und aktualisieren
+    unser Wissen entsprechend. Das Buch richtet sich an alle, die Bayes-Modelle nicht nur
+    verstehen, sondern selbst berechnen und interpretieren wollen. Der Aufbau folgt der
+    Logik der Sache: von Wahrscheinlichkeit und Verteilungen über den Kern der
+    Bayes-Statistik am Beispiel des Globus-Versuchs bis zu linearen Modellen und
+    Kausalität.
   date: today
   reader-mode: true
   page-footer:


### PR DESCRIPTION
## Summary
- Klappentext (gemeinsam mit dem Nutzer erarbeitet) als description auf Projekt- und book-Ebene in `_quarto.yml` eingetragen.

## Test plan
- [ ] `quarto render` prüft, ob die YAML-Änderung sauber verarbeitet wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPTNg6kKNw6ZHr8urM4FgX