### PR TITLE
Farbkontrast für Schwarz-weiß-Druck korrigieren

### DIFF
--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -961,12 +961,14 @@ kidiq |>
   geom_abline(slope = coef(m10.4)[2],
               intercept = coef(m10.4)[1],
               linewidth = 1,
-              color =  okabeito_colors()[1] ) +
+              color =  okabeito_colors()[5] ) +
   geom_abline(slope = coef(m10.4)[2]+coef(m10.4)[4],
               intercept = coef(m10.4)[1] + coef(m10.4)[3],
               linewidth = 2,
-              color = okabeito_colors()[2]) +
-  scale_color_okabeito() +
+              color = okabeito_colors()[4]) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_color_okabeito(order = c(5, 4)) +
   scale_x_continuous(limits = c(0, 140)) +
   theme(legend.position = c(0.9, 0.2)) +
   theme_minimal() +
@@ -1119,12 +1121,14 @@ kidiq |>
   geom_abline(slope = coef(m10.5)[2],
               intercept = coef(m10.5)[1],
               linewidth = 1,
-              color =  okabeito_colors()[1] ) +
+              color =  okabeito_colors()[5] ) +
   geom_abline(slope = coef(m10.5)[2]+coef(m10.5)[4],
               intercept = coef(m10.5)[1] + coef(m10.5)[3],
               linewidth = 2,
-              color = okabeito_colors()[2]) +
-  scale_color_okabeito() +
+              color = okabeito_colors()[4]) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_color_okabeito(order = c(5, 4)) +
   theme(legend.position = c(0.9, 0.2))  +
   geom_vline(xintercept = 0, linetype = "dashed", color = "grey40") +
   theme_minimal()
@@ -1418,7 +1422,10 @@ Der Unterschied im mittleren Gewicht von den Gruppen Chinstrap und Gentoo zur Re
 #| fig-cap: "Effekt der UV: Unterschiede zur Referenzgruppe (95%-HDI)"
 #| label: fig-m106-params
 
-plot(hdi(m10.6)) + scale_fill_okabeito()
+plot(hdi(m10.6)) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4))
 ```
 
 
@@ -2123,7 +2130,10 @@ parameters(m10.12) |>
 ```{r m10-11-params-plot}
 #| label: fig-m1011hdi
 #| fig-cap: "Im Standard wird ein 95%-Intervall gezeigt bzw. berechnet; hier das ETI für m10.12"
-plot(eti(m10.12)) + scale_fill_okabeito()
+plot(eti(m10.12)) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4))
 ```
 
 

--- a/1050-Schaetzen-Testen.qmd
+++ b/1050-Schaetzen-Testen.qmd
@@ -737,7 +737,10 @@ m_penguins_species_r2 <-
   as_tibble()
 
 hdi(m_penguins_species_r2) |>  # Intervallgrenzen der Post-Verteilung von R2
-  plot()  # visualisieren
+  plot() +  # visualisieren
+  # Blau/Amber statt der Standardfarben Blau/Rot, die im Graustufendruck
+  # fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4))
 ```
 
 $R^2$ und $\sigma$ sind negativ assoziiert:

--- a/R-Code/kausalstudie1.R
+++ b/R-Code/kausalstudie1.R
@@ -42,7 +42,9 @@ plot_kausalstudie_a <-
   ) +
   facet_wrap(~Gruppe) +
   scale_y_continuous(labels = scales::percent) +
-  scale_fill_okabeito() +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4)) +
   labs(
     x = "",
     y = "Anteil",

--- a/R-Code/plot_maschine_schrott.R
+++ b/R-Code/plot_maschine_schrott.R
@@ -80,8 +80,11 @@ plot_maschine_schrott <-
     y = "Anteil an der Produktion",
     fill = NULL
   ) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
   scale_fill_okabeito(
-    labels = c("Ausschuss", "OK")
+    labels = c("Ausschuss", "OK"),
+    order = c(5, 4)
   ) +
   see::theme_modern() +
   theme(legend.position = "bottom")


### PR DESCRIPTION
## Zusammenfassung
- Abb. 2.4, 5.13, 11.6, 12.9, 12.10, 12.14 und 12.19 nutzten Farbpaare (Orange/Hellblau bzw. Blau/Rot), die im Graustufendruck fast identische Helligkeit haben und dadurch kaum unterscheidbar sind
- Ersetzt durch das Okabe-Ito-Paar Blau (#0072B2, Grauwert ~87) / Amber (#F5C710, Grauwert ~192) mit deutlich höherem Kontrast

## Test plan
- [x] Betroffene Kapitel gerendert (0200-zielarten, 0350-wskt2, 1050-Schaetzen-Testen, 1000-metrische-AV)
- [x] Alle 7 Abbildungen in Graustufen konvertiert und visuell auf Kontrast geprüft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cef6wfuEvbDeDqWFkyxVjb