### PR TITLE
Entferne einzelne theme_minimal()-Overrides zugunsten des globalen th…

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -261,7 +261,6 @@ ggplot(noten2) +
   geom_point() +
   labs(x = "Lernzeit",
        y = "Klausurpunkte") +
-  theme_minimal() +
   theme_large_text()
 
 p_ali_punktschaetzung <- 
@@ -271,8 +270,7 @@ p_ali_punktschaetzung <-
   geom_vline(xintercept = mean(noten2$x), linetype = "dashed", color = "grey") +  
   geom_hline(yintercept = mean(noten2$y), linetype = "dashed", color = "grey") +   
   geom_abline(slope = coef(lm_ali)[2], intercept = coef(lm_ali)[1], color = modelcol, size = 1.5) +
-  theme_minimal() +
-  annotate("label", x = mean(noten2$x), y = -Inf, 
+  annotate("label", x = mean(noten2$x), y = -Inf,
            label = paste0("MW: ", round(mean(noten2$x))), vjust = "bottom") +
   annotate("label", y = mean(noten2$y), x = -Inf, 
            label = paste0("MW: ", round(mean(noten2$y))), hjust = "left")   +
@@ -894,14 +892,12 @@ mtcars$am <- factor(mtcars$am)
 ggplot(mtcars) +
   aes(x = hp, y = mpg) +
   geom_point() +
-  geom_smooth(method = "lm") +
-  theme_minimal()
+  geom_smooth(method = "lm")
 
 ggplot(mtcars) +
   aes(x = hp, y = mpg, color = am) +
   geom_point() +
   geom_smooth(method = "lm") +
-  theme_minimal() +
   scale_color_okabeito() +
   theme(legend.position = c(0.9, .90))
 ```

--- a/0250-inferenz.qmd
+++ b/0250-inferenz.qmd
@@ -375,7 +375,6 @@ p_toni_regr_b0 <-
   geom_point() +
  geom_abline(slope = coef(lm_toni)[2], 
              intercept = coef(lm_toni)[1], color = modelcol, size = 1.5) +
-  theme_minimal() +
    scale_x_continuous(breaks = c(20, 40, 60, 80, 100)) +
   labs(x = "Lernzeit",
        y = "Klausurpunkte") +
@@ -393,7 +392,6 @@ p_toni_regr_b1 <-
   ggplot(aes(x, y)) +
   geom_point() +
  geom_abline(slope = coef(lm_toni)[2], intercept = coef(lm_toni)[1], color = modelcol, size = 1.5) +
-  theme_minimal() +
    scale_x_continuous(breaks = c(20, 40, 60, 80, 100)) +
   labs(x = "Lernzeit",
        y = "Klausurpunkte") +

--- a/0300-Wskt.qmd
+++ b/0300-Wskt.qmd
@@ -1134,7 +1134,6 @@ ggplot(data.frame(x=c(0:4), y = 0), aes(x,y)) +
   geom_point(size = 5, alpha = .7) +
   scale_y_continuous(limits = c(-1,1), breaks = NULL) +
   scale_x_continuous(breaks = 0:4, labels = 0:4) +
-  theme_minimal() +
   labs(y = "", x = "")
 
 ```
@@ -1425,7 +1424,6 @@ ggplot(data.frame(x=0, y = 0), aes(x,y)) +
   scale_y_continuous(limits = c(-1,1), breaks = NULL) +
   scale_x_continuous(breaks = c(0, 50, 100, 150, 200)) +
   annotate("segment", x = 0, xend = 200, y = 0, yend = 0, color = "red")  +
-  theme_minimal() +
   annotate("label", x = 200, y = 0, label = "...") +
   labs(y = "", x = "")
 ```
@@ -1563,8 +1561,7 @@ d <-
 ggplot(d, aes(x,y)) +
   geom_point(alpha = .5) +
   geom_line() +
-  scale_x_continuous(breaks = 1:10) +
-  theme_minimal()
+  scale_x_continuous(breaks = 1:10)
 ```
 
 

--- a/0400-Verteilungen.qmd
+++ b/0400-Verteilungen.qmd
@@ -251,7 +251,6 @@ d <- tibble(id = 1:5,
 p_urn <- 
   ggplot(d) +
   aes(x = id, label = id) +
-  theme_minimal() +
   annotate("rect", xmin = 0, xmax = 6, ymin = 0, ymax = 2, fill = "grey80", alpha = .8) +
   geom_point(size = 10, y = 1, aes(color = event) )+
   geom_text(aes(label = id), y = 1) +
@@ -319,7 +318,6 @@ d <-
 
 p_urn2 <- ggplot(d) +
   aes(x = id) +
-  theme_minimal() +
   annotate("rect", xmin = 0, xmax = 4, ymin = 0, ymax = 2, fill = "grey80", alpha = .8) +
   geom_point(size = 10, y = 1, aes(color = event) )+
   geom_text(aes(label = event), y = 1) +
@@ -1057,7 +1055,6 @@ ggplot(df, aes(x, y)) +
   geom_area(data = df_left, aes(x, y), fill = "grey90") +
   geom_area(data = df_right, aes(x, y), fill = "grey80") +
   #geom_line(size = 1) +
-  theme_minimal() +
   scale_y_continuous(NULL, breaks = NULL) +
   theme(
     axis.title.y = element_blank(),

--- a/0600-Post.qmd
+++ b/0600-Post.qmd
@@ -152,10 +152,9 @@ bayesbox_6w_9v  |>
   aes(x = p_grid, y = post) +
   geom_point(alpha = .5, size = 3) +
   geom_line() +
-  scale_y_continuous("Posterior-Wahrscheinlichkeit", 
+  scale_y_continuous("Posterior-Wahrscheinlichkeit",
                      breaks = NULL) +
-  theme_minimal()  +
-  annotate("point", x = .7, 
+  annotate("point", x = .7,
            y = .2668, 
            color = "red", 
            alpha = .7,
@@ -181,10 +180,9 @@ bayesbox_6w_9v  |>
   aes(x = p_grid, y = post) +
   geom_point(alpha = .5, size = 3) +
   geom_line() +
-  scale_y_continuous("Posterior-Wahrscheinlichkeit", 
+  scale_y_continuous("Posterior-Wahrscheinlichkeit",
                      breaks = NULL) +
-  theme_minimal() +
-  labs(x = "Anteil Wasser (p)") 
+  labs(x = "Anteil Wasser (p)")
 
 p_d
 ```
@@ -532,8 +530,7 @@ p0 <-
   geom_point() +
   labs(title = "Post-Verteilung \nexakt",
   y = "Wahrscheinlichkeit",
-  x = "Wasseranteil") +
-  theme_minimal()
+  x = "Wasseranteil")
 
 p1 <-
   samples_g100 |> 
@@ -543,8 +540,7 @@ p1 <-
   scale_x_continuous("Wasseranteil", 
                      limits = c(0, 1)) +
   labs(y = "Nummer der Stichprobe",
-       title = "Stichproben \naus der Post")  +
-  theme_minimal()
+       title = "Stichproben \naus der Post")
 
 p2 <-
 samples_g100 |> 
@@ -553,8 +549,7 @@ samples_g100 |>
   scale_x_continuous("Anteil Wasser (p)", 
                      limits = c(0, 1)) +
   labs(y = "Wahrscheinlichkeitsdichte",
-       title = "Stichproben \naus der Post") +
-  theme_minimal()
+       title = "Stichproben \naus der Post")
 
 p_samples_exact <-
   samples_g100 |> 
@@ -626,8 +621,7 @@ ggplot(aes(x = p_grid)) +
   geom_vline(xintercept = c(mode_rounded), color = "#E69F00FF")  +
   geom_vline(xintercept = c(mavg), color = "#56B4E9FF")  +
   geom_vline(xintercept = c(md), color = "#009E73FF")  +
-  theme_minimal() +
-  annotate("label", x = mode_rounded, y = 0, 
+  annotate("label", x = mode_rounded, y = 0,
     label = glue::glue("Modus: {mode_rounded}"), fill = "#E69F00FF") +
   annotate("label", x = mavg, y = 10000, label = glue::glue("MW: {mavg}"), fill = "#56B4E9FF") +
   annotate("label", x = md, y = 20000, label = glue::glue("Median: {md}"), fill = "#009E73FF")
@@ -1209,7 +1203,6 @@ p1 <-
             fill = "grey75") +
   geom_line() +
   scale_x_continuous(breaks = seq(from = 0, to = 1, by = .1)) +
-  theme_minimal() +
   labs(y = "Wahrscheinlichkeit",
     x = "Wasseranteil") +
   annotate("point", x = 1, y = max(bayesbox_3w_3v$post_33),
@@ -1233,7 +1226,6 @@ p2 <-
                      p_grid <= hdi_50_up),
             fill = "grey75") +
   geom_line()  +
-  theme_minimal() +
   labs(y = "Wahrscheinlichkeit",
     x = "Wasseranteil") +
   annotate("point", x = 1, y = max(bayesbox_3w_3v$post_33),
@@ -1342,8 +1334,7 @@ bayesbox_3w_3v |>
             hjust = 0) +
   labs(x = "Anteil Wasser (p)",
        y = "Wahrscheinlichkeitsdichte") +
-  theme(panel.grid = element_blank()) +
-  theme_minimal()
+  theme(panel.grid = element_blank())
 
 ```
 

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -199,7 +199,6 @@ kung_erwachsen |>
   ggplot(aes(x = value)) +
   geom_histogram(aes(y = after_stat(density)), fill = "grey60") +  # Histogram with density scaling
   geom_density(color = "blue", size = 1) +  # Density plot in blue
-  theme_minimal() +  # Optional: Clean theme
   facet_wrap(~ variable, scales = "free") + # Faceting by variable, free scales for each facet
   scale_y_continuous(breaks = NULL)
 ```
@@ -420,8 +419,7 @@ kung_zentriert |>
   ggplot() +
   geom_histogram(aes(x = weight), fill = "grey40") +
   geom_histogram(aes(x = weight_c), fill = "black") +
-  theme_minimal() +
-  geom_segment(x = mean(kung_zentriert$weight), 
+  geom_segment(x = mean(kung_zentriert$weight),
                xend = 0, 
                y = 20, yend = 20, 
                arrow = arrow(length = unit(0.2, "cm"), type = "closed"),

--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -968,8 +968,6 @@ kidiq |>
               color = okabeito_colors()[2]) +
   scale_color_okabeito() +
   scale_x_continuous(limits = c(0, 140)) +
-  theme(legend.position = c(0.9, 0.2)) +
-  theme_minimal() +
   theme(legend.position = c(0.9, 0.1))
 ```
 
@@ -1126,8 +1124,7 @@ kidiq |>
               color = okabeito_colors()[2]) +
   scale_color_okabeito() +
   theme(legend.position = c(0.9, 0.2))  +
-  geom_vline(xintercept = 0, linetype = "dashed", color = "grey40") +
-  theme_minimal()
+  geom_vline(xintercept = 0, linetype = "dashed", color = "grey40")
 ```
 
 

--- a/1150-konfundierung.qmd
+++ b/1150-konfundierung.qmd
@@ -550,8 +550,7 @@ d |>
   ggplot() +
   aes(x = bedrooms, y = price) +
   geom_jitter(alpha = .3) +
-  geom_smooth(method = "lm") + 
-  theme_minimal()
+  geom_smooth(method = "lm")
 ```
 
 

--- a/1180-kausalatome.qmd
+++ b/1180-kausalatome.qmd
@@ -132,7 +132,6 @@ p_coll1 <-
       y = y) +
   geom_point() +
  # scale_color_manual(values = c("grey80", "black")) +
-  theme_minimal() +
   labs(x = "Schönheit",
        y = "Schlauheit") +
     theme(legend.position = "bottom",
@@ -173,7 +172,6 @@ p_coll2 <-
   scale_color_manual(
     values = c("kein Date" = "grey80", "Date" = "black"),
     guide = guide_legend(override.aes = list(label = c("✓", "✗")))) +
-  theme_minimal() +
   labs(
     x = "Schönheit",
     y = "Schlauheit",

--- a/_common.R
+++ b/_common.R
@@ -7,7 +7,7 @@ base_family <- "Lato Regular"
 
 # Define a custom ggplot theme with larger text
 theme_large_text <- function(base_size = 18) {
-  theme_minimal(base_size = base_size) +
+  see::theme_modern(base_size = base_size) +
     theme(
       text = element_text(size = base_size + 4),          # Base text size
       axis.title = element_text(size = base_size + 6),    # Axis title text size

--- a/children/Exponentialverteilung.qmd
+++ b/children/Exponentialverteilung.qmd
@@ -39,7 +39,6 @@ ggplot(df, aes(x)) +
   annotate("label", x = 2.5, y = dexp(2.5, rate = 1) + 0.02, 
            label = "Exponenzial", color = "#56B4E9", hjust = 0) +
   # Theme adjustments
-  theme_minimal() +
   scale_y_continuous(NULL, breaks = NULL) +
   theme(
     axis.title.y = element_blank(),
@@ -73,7 +72,6 @@ data <- data.frame(x = x_vals, y = y_vals)
 
 ggplot(data, aes(x = x, y = y)) +
   geom_line(color = okabeito_colors()[1], size = 1) +
-  theme_minimal() +
  # labs(title = "Exponential Distribution", x = "", y = "Density") +
   theme(plot.title = element_text(hjust = 0.5)) +
   # Add emojis as text annotations

--- a/children/plots-bed-wskt.qmd
+++ b/children/plots-bed-wskt.qmd
@@ -16,7 +16,6 @@ plot16a <-
            color = "#56B4E9FF", alpha = .5, fill = "#56B4E9FF") +
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -32,7 +31,6 @@ plot_pr_b <-
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate("label", x = .5, y = .75, label = "Pr(B) = 50%") +
-  theme_minimal() +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -47,7 +45,6 @@ plot_pr_a <-
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate("label", x = .75, y = .5, label = "Pr(A) = 50%") +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -69,7 +66,6 @@ ggplot(data.frame(A = c(0, 1),
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate(geom = "label", x = .75, y = 0.75, label = "A,B", color = "#E69F00FF") +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 

--- a/children/plots_wskt.R
+++ b/children/plots_wskt.R
@@ -13,7 +13,6 @@ plot16a <-
            color = "#56B4E9FF", alpha = .5, fill = "#56B4E9FF") +
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -29,7 +28,6 @@ plot_pr_b <-
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate("label", x = .5, y = .75, label = "Pr(B) = 50%") +
-  theme_minimal() +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -44,7 +42,6 @@ plot_pr_a <-
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate("label", x = .75, y = .5, label = "Pr(A) = 50%") +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 
@@ -66,7 +63,6 @@ plot_pr_ab <-
   scale_x_continuous(breaks = c(0.25, 0.75), labels = c("¬A", "A")) +
   scale_y_continuous(breaks = c(0.25, 0.75), labels = c("¬B", "B")) +
   annotate(geom = "label", x = .75, y = 0.75, label = "A,B", color = "#E69F00FF") +
-  theme_minimal()  +
   theme(axis.text = element_text(size = 18)) +
   labs(x = "", y = "")
 

--- a/funs/binomial_plot.R
+++ b/funs/binomial_plot.R
@@ -8,6 +8,5 @@ binomial_plot <- function(n, p){
     #   geom_segment(aes(xend = Treffer, yend = 0)) + 
     #  geom_point(color = "red", size = 5, alpha = .5) +
     scale_x_continuous(breaks = 0:n) +
-    theme_minimal() +
     geom_label(aes(label = round(Wahrscheinlichkeit, 2)))
 }

--- a/funs/plot_binom_likelihood.R
+++ b/funs/plot_binom_likelihood.R
@@ -18,8 +18,7 @@ plot_binom_likelihood <- function(x, n, p_step = 0.1) {
       subtitle = paste(x, "Treffer bei", n, "Versuchen"),
       x = "p",
       y = "L(p)"
-    ) +
-    theme_minimal(base_size = 14)
+    )
 }
 
 # Beispielaufruf: 6 Erfolge bei 9 Versuchen


### PR DESCRIPTION
…eme_modern

Mehrere Diagramme in Kapiteln und children/-Fragmenten setzten explizit theme_minimal() bzw. theme_minimal(base_size=...) und überschrieben damit den in _common.R via theme_set(see::theme_modern()) gesetzten globalen Standard. Auch theme_large_text() basierte intern auf theme_minimal() statt auf theme_modern(). theme_void()-Aufrufe (Baumdiagramm, Urnen- Illustrationen ohne Achsen) bleiben unangetastet, da sie keine Theme-Vorschrift sondern bewusst achsenlose Illustrationen sind.


Claude-Session: https://claude.ai/code/session_01KR3J4Dj7btfjV5RUJxfWtT