### PR TITLE
_common.R: cairo_pdf statt Standard-pdf()-Device für Figure-PDFs

### DIFF
--- a/_common.R
+++ b/_common.R
@@ -23,8 +23,8 @@ theme_large_text <- function(base_size = 18) {
 
 ggplot2::theme_set(see::theme_modern())
 
-knitr::opts_chunk$set(tidy = FALSE, 
-                      width = 60, 
+knitr::opts_chunk$set(tidy = FALSE,
+                      width = 60,
                       fig.retina = 2,
                       max.print = 100,
                       fig.dpi = 300,
@@ -32,7 +32,10 @@ knitr::opts_chunk$set(tidy = FALSE,
                       out.width = "70%", # enough room to breath
                       fig.width = 6,     # reasonable size
                       fig.asp = 0.618,   # golden ratio
-                      fig.align = "center" # mostly what I want
+                      fig.align = "center", # mostly what I want
+                      dev = "cairo_pdf" # R's default pdf() device falls back to
+                      # non-embeddable base-14 fonts (Helvetica); cairo_pdf
+                      # embeds the actual fonts so KDP/PDF validators accept them
 )
 
 


### PR DESCRIPTION
R's Standard-pdf()-Device fällt für unbekannte Fontfamilien auf die nicht-einbettbaren PDF-Basisschriften (Helvetica etc.) zurück. Das führt dazu, dass Amazon KDP beim Buch-PDF "Schriftarten nicht eingebunden" meldet, weil die in Start-Bayes!.tex eingebundenen figure-pdf/*.pdf-Abbildungen Helvetica ohne Embedding referenzieren. cairo_pdf embettet die tatsächlich verwendeten Fonts vollständig.


Claude-Session: https://claude.ai/code/session_01TGpjR7nGNdWw8VZJqBUKV4