### PR TITLE
Fix zerschossenes Regressions-Diagramm in Kap. 0200

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -893,7 +893,6 @@ ggplot(mtcars) +
   aes(x = hp, y = mpg) +
   geom_point() +
   geom_smooth(method = "lm")
-  geom_smooth(method = "lm") 
 
 ggplot(mtcars) +
   aes(x = hp, y = mpg, color = am) +


### PR DESCRIPTION
## Zusammenfassung
- In der Abbildung `fig-regr-rules` (Kap. 0200, „Die drei Zielarten der Statistik") fehlte ein `+` zwischen zwei `geom_smooth()`-Aufrufen in der ersten ggplot-Kette.
- Dadurch endete die erste `ggplot()`-Kette vorzeitig und wurde automatisch ausgegeben; der zweite, isolierte `geom_smooth(method = "lm")`-Aufruf wurde als eigener Top-Level-Ausdruck gewertet und als Textmüll ("## geom_smooth: na.rm = FALSE, orientation = NA, ...") über das zweite Panel gedruckt.
- Fix: doppelte, überflüssige Zeile entfernt.

## Test plan
- [x] Chapter-Cache gelöscht und `quarto render 0200-zielarten.qmd` erneut ausgeführt
- [x] `docs/0200-zielarten.html` enthält keine `geom_smooth: na.rm`-Textreste mehr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBq2mqpvHGNcxDR5iF8JZE