### PR TITLE
Fix babel-Shorthand-Bug: "s wird faelschlich zu Eszett im PDF

### DIFF
--- a/specifics/style.tex
+++ b/specifics/style.tex
@@ -16,6 +16,19 @@
 % pruefen, ob das zu einer doppelten babel-Ladung fuehrt (dann diese Zeile
 % wieder auskommentieren).
 \usepackage[ngerman]{babel}
+% ngerman aktiviert babel-Shorthands (z. B. "a, "s, "z fuer Umlaute/ss),
+% urspruenglich gedacht zur Eingabe deutscher Sonderzeichen ohne native
+% Tastaturbelegung. Wir tippen Umlaute/ss aber direkt als Unicode
+% (fontspec/xelatex/lualatex), daher stoeren die Shorthands nur -- z. B.
+% wird in Code-Spans wie `pak::pak("sebastiansauer/prada")` die
+% Zeichenfolge "s faelschlich zu Eszett (ss) expandiert. Deshalb hier
+% deaktivieren. \shorthandoff direkt hier im Preamble reicht nicht, weil
+% babel per \AtBeginDocument beim \begin{document} die Shorthands fuer die
+% Hauptsprache wieder aktiviert (das passiert NACH dem Preamble) -- daher
+% muss unser \shorthandoff ebenfalls per \AtBeginDocument registriert
+% werden, damit es (in Registrierungsreihenfolge) nach babels eigenem Hook
+% laeuft.
+\AtBeginDocument{\shorthandoff{"}}
 % csquotes wird zusammen mit der Metadaten-Variable "csquotes: true" im
 % titlepage-pdf-Formatblock von _quarto.yml gebraucht: Pandoc gibt
 % Anfuehrungszeichen aus geraden "..." dann als \enquote{...} statt als


### PR DESCRIPTION
## Zusammenfassung
- Screenshot zeigte im PDF `pak::pak(ßebastiansauer/prada")` statt `pak::pak("sebastiansauer/prada")`.
- Ursache war kein Tippfehler im Quelltext, sondern ein LaTeX-Rendering-Bug: `\usepackage[ngerman]{babel}` aktiviert die babel-Shorthand `"s` (urspruenglich zur Eingabe von ß ohne native Tastaturbelegung gedacht), die in Inline-Code-Spans wie `` `pak::pak("sebastiansauer/prada")` `` (gerendert als `\texttt{...}`, nicht als Verbatim mit geänderten Catcodes) die Zeichenfolge `"s` faelschlich zu ß expandierte.
- Fix: `\AtBeginDocument{\shorthandoff{"}}` in `specifics/style.tex`, damit die Shorthand-Deaktivierung nach babels eigenem `\AtBeginDocument`-Hook (der die Shorthands aktiviert) laeuft.

## Test plan
- [x] `quarto render 0600-Post.qmd --to titlepage-pdf` erfolgreich
- [x] `pdftotext` bestaetigt: `pak::pak("sebastiansauer/prada")` erscheint jetzt korrekt ohne ß

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSYyLuHERY6tXyvrEPZRPo