### PR TITLE
Legende in Abbildung 12.9 höher setzen

### DIFF
--- a/1000-metrische-AV.qmd
+++ b/1000-metrische-AV.qmd
@@ -974,7 +974,7 @@ kidiq |>
   # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
   scale_color_okabeito(order = c(5, 4)) +
   scale_x_continuous(limits = c(0, 140)) +
-  theme(legend.position = c(0.9, 0.1))
+  theme(legend.position = c(0.9, 0.2))
 ```
 
 


### PR DESCRIPTION
## Summary
- Die Legende von Abbildung 12.9 (`fig-m104` in `1000-metrische-AV.qmd`) schnitt die X-Achse, da `legend.position = c(0.9, 0.1)` sie zu tief platzierte.
- Position auf `c(0.9, 0.2)` angehoben.

## Test plan
- [x] Kapitel `1000-metrische-AV.qmd` gerendert und die Abbildung visuell geprüft: Legende überschneidet die X-Achse nicht mehr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LV4VgRVpGBsw9fMTmMiFhw