### PR TITLE
Verhindere hässlichen Zeilenumbruch bei "Punkt-Vorhersage" in Fig-Sub…

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -249,7 +249,7 @@ ali_vorhersageintervall <- predict(lm_ali, newdata =  data.frame(x=42),
 #| fig-cap: "Noten und Lernzeit: Rohdaten (a) und mit Modell (b). Mittelwerte sind mit gestrichelten Linien eingezeichnet. Die Vorhersage für Ali ist farbig markiert. Ali hat 42 Stunden gelernt für die Klausur; das Modell sagt ihm 83 Punkte (von 100) bzw. einen Bereich von 62 bis 104 Punkten voraus."
 #| layout-ncol: 2
 #| fig-subcap: 
-#|   - "Regressionsgerade mit Punkt-Vorhersage für Ali"
+#|   - "Regressionsgerade mit Punkt‑Vorhersage für Ali"
 #|   - "Regressionsgerade mit Vorhersagebereich (und herangezoomt) für Ali"
 
 #noten2 <- read.csv(noten2, "data/noten2.csv")


### PR DESCRIPTION
…caption

Ersetzt den normalen Bindestrich durch einen nicht-trennenden Bindestrich (U+2011), damit LaTeX die Bildunterschrift nicht mitten im zusammengesetzten Wort umbricht.


Claude-Session: https://claude.ai/code/session_01Lerbpfd1CRioQkH1MEoZSD