### PR TITLE
Fix Y-Achsen-Ticks in Abb. 2.3 rechts (weniger Labels)

### DIFF
--- a/0200-zielarten.qmd
+++ b/0200-zielarten.qmd
@@ -306,6 +306,7 @@ p_ali_punktschaetzung +
            ymin = ali_vorhersageintervall[1, "lwr"],
            ymax = ali_vorhersageintervall[1, "upr"],
            color = ycol) +
+  scale_y_continuous(breaks = c(60, 80, 100, 120)) +
   coord_cartesian(xlim = c(32, 52),
                   ylim = c(55, 112))
 ```


### PR DESCRIPTION
Der Fix (scale_y_continuous mit breaks) existierte bereits im unmerged Branch worktree-fig23-yaxis, war aber nie auf main übernommen worden, weshalb main weiterhin gedrängte Y-Achsen-Ticks gerendert hat.


Claude-Session: https://claude.ai/code/session_01A1PS8jQy1HoW78PpLg3wz2