### PR TITLE
Okabe-Ito-Farbkontrast in weiteren Diagrammen korrigieren

### DIFF
--- a/0400-Verteilungen.qmd
+++ b/0400-Verteilungen.qmd
@@ -87,8 +87,12 @@ source("funs/binomial_plot.R")
 #| echo: false
 #| message: false
 #scale_color_okabeito()
-scale_colour_discrete <- function(...) 
-  scale_color_okabeito()
+scale_colour_discrete <- function(...)
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast) —
+  # betrifft hier ausschließlich Diagramme mit genau zwei Kategorien
+  # (Treffer/Niete bzw. T/N)
+  scale_color_okabeito(order = c(5, 4))
 ```
 
 
@@ -256,7 +260,9 @@ p_urn <-
   geom_text(aes(label = id), y = 1) +
   theme(axis.text = element_blank()) +
   labs(x = "", color = "") +
-  scale_color_okabeito()
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_color_okabeito(order = c(5, 4))
 
 d2 <-
   tibble(id = 1:1e3,

--- a/0600-Post.qmd
+++ b/0600-Post.qmd
@@ -1061,7 +1061,9 @@ Intervalle (Bereiche), die die "abzuschneidende" Wahrscheinlichkeitsmasse hälft
 
 eti_80 <- eti(bayesbox_g100_samples$p_grid, ci = .8)
 plot(eti_80) +
-  scale_fill_okabeito()  +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4))  +
   labs(title = paste0("80%-ETI: Die mittleren 80% der Wahrscheinlichkeit \nliegen zwischen ", 
                      round(eti_80$CI_low, 2), " und ", 
                      round(eti_80$CI_high, 2)),

--- a/0900-lineare-modelle.qmd
+++ b/0900-lineare-modelle.qmd
@@ -1250,7 +1250,9 @@ plot_condition <-
   labs(color = "Gewicht",
        x = "Gewicht (weight)",
        y = "Größe (height)") +
-  scale_color_okabeito()
+  # order = c(5, 3, 8, 4): Blau/Grün/Grau/Amber statt der Standardreihenfolge,
+  # da Orange und Hellblau im Graustufendruck fast identisch hell sind
+  scale_color_okabeito(order = c(5, 3, 8, 4))
 
 
 k <- 3

--- a/1200-abschluss.qmd
+++ b/1200-abschluss.qmd
@@ -318,7 +318,10 @@ Und schauen wir uns die Post-Verteilung an, mit eingezeichnetem HDI, s. @fig-pos
 ```{r echo = FALSE}
 #| label: fig-post-m3
 #| fig-cap: "Post-Verteilung (HDI) von m3"
-plot(hdi(m3)) + scale_fill_okabeito()
+plot(hdi(m3)) +
+  # order = c(5, 4): Blau/Amber statt Orange/Hellblau, da Letztere im
+  # Graustufendruck fast identisch hell sind (schlechter S/W-Kontrast)
+  scale_fill_okabeito(order = c(5, 4))
 ```
 
 


### PR DESCRIPTION
## Summary
- Ergänzt `order = c(...)` bei vier weiteren `scale_color_okabeito()`/`scale_fill_okabeito()`-Aufrufen, die noch die Standardreihenfolge (Orange/Hellblau) nutzten und dadurch im Graustufendruck kaum unterscheidbar waren.
- Betrifft: `fig-post-m3` (HDI, `1200-abschluss.qmd`), `fig-eti-hdi` (ETI, `0600-Post.qmd`), `fig-sort3`/`p_urn` (`0400-Verteilungen.qmd`, über den globalen `scale_colour_discrete`-Override sowie eine explizite Stelle) und `plot_condition` (`0900-lineare-modelle.qmd`, 4 Kategorien).
- Analog zu den bereits gemergten PRs #35/#36/#37.
- Bewusst NICHT angefasst: die toten `scale_colour_discrete`-Overrides in `0300-Wskt.qmd`/`0350-wskt2.qmd`/`0200-zielarten.qmd`, die aktuell kein gerendertes Diagramm betreffen und deren pauschale Umstellung riskant wäre.

## Test plan
- [x] `quarto render 0400-Verteilungen.qmd --to html` — erfolgreich
- [x] `quarto render 0600-Post.qmd --to html` — erfolgreich
- [x] `quarto render 0900-lineare-modelle.qmd --to html` — erfolgreich
- [x] `quarto render 1200-abschluss.qmd --to html` — erfolgreich
- [x] `fig-post-m3` und `fig-eti-hdi` visuell per PDF→PNG geprüft: Blau/Amber statt Orange/Hellblau

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDcV4YdWyQMFzToPpLAnoW