### PR TITLE
Ignoriere PDF-Render-Artefakte in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ Start-Bayes!.tex
 *.log
 *.toc
 
+# PDF-Render-Artefakte (quarto render --to titlepage-pdf)
+/index.tex
+/index.pdf
+luatex.*/
+
 
 # Debugging
 


### PR DESCRIPTION
## Summary
- `index.tex`, `index.pdf` und `luatex.*/` (Nebenprodukte von `quarto render --to titlepage-pdf`) tauchten bisher als untracked auf
- `.gitignore` um diese Pfade ergänzt

## Test plan
- [x] `.gitignore`-Muster manuell gegen die beobachteten Dateinamen geprüft