### PR TITLE
Font-Einbettung im PDF-Export reparieren (KDP-Validierungsfehler)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -157,7 +157,9 @@ knitr:
     fig.align: center
     rows.print: 5
     # comment: "#>"
-    #dev: cairo_pdf
+    # dev: cairo_pdf wird NICHT hier (global) gesetzt, sondern nur unter
+    # format.titlepage-pdf.knitr.opts_chunk (s.u.) -- global wuerde es auch
+    # das HTML-Format treffen, wo cairo_pdf als Grafikgeraet nicht passt.
     R.options:
       knitr. graphics.auto_pdf: true
 
@@ -272,6 +274,20 @@ format:
     # babel geladenen Sprache automatisch den deutschen Stil „..." waehlt.
     csquotes: true
     fig-format: pdf
+    # fig-format: pdf oben setzt intern (via rmarkdown::knitr_options())
+    # knitr::opts_chunk$set(dev = "pdf") -- das ist R's Standard-pdf()-Geraet,
+    # das nur Base-14-Fonts (Helvetica etc.) OHNE Einbettung erzeugt und
+    # deshalb von KDPs PDF-Validator bemaengelt wird. _common.R versucht das
+    # mit dev="cairo_pdf" zu uebersteuern, aber das passiert beim R-Start
+    # (ueber .Rprofile), also VOR diesem fig-format-Schritt, der spaeter beim
+    # Dokument-Setup laeuft und cairo_pdf wieder mit "pdf" ueberschreibt.
+    # Dieser knitr.opts_chunk-Block hier wird von Quarto per merge_lists()
+    # NACH dem fig-format-Schritt eingemischt und gewinnt bei Namenskollision,
+    # daher wirkt er tatsaechlich. Nur hier (format-scoped), nicht global in
+    # knitr.opts_chunk oben, damit das HTML-Format cairo_pdf nicht abbekommt.
+    knitr:
+      opts_chunk:
+        dev: cairo_pdf
     # Zwischenseiten ganz vorne im PDF (Reihenfolge wie gelistet): Copyright-
     # seite, Widmung, danach eine Leerseite -- vor der eigentlichen
     # Titelseite, die die Extension selbst erzeugt (titlepage: classic-lined


### PR DESCRIPTION
## Zusammenfassung

KDP bemängelt weiterhin fehlende Font-Einbettung in Abbildungen, obwohl der frühere Fix in 7f87def (`_common.R`: `dev = "cairo_pdf"`) bereits gemergt war und die Druckfahne visuell korrekt aussieht.

**Ursache:** `format.titlepage-pdf.fig-format: pdf` in `_quarto.yml` setzt über `rmarkdown::knitr_options()` intern `knitr::opts_chunk$set(dev = "pdf")` — R's Standard-`pdf()`-Gerät, das nur nicht einbettbare Base-14-Fonts (Helvetica) erzeugt. Das passiert beim Dokument-Setup, also **nach** `_common.R` (das über `.Rprofile` beim R-Start läuft) — der dortige `dev = "cairo_pdf"`-Versuch wird dadurch stillschweigend wieder überschrieben. Das erklärt, warum die Druckfahne optisch stimmt (der PDF-Viewer substituiert lokal installierte Fonts), KDPs Validator aber trotzdem meckert: die tatsächlich eingebetteten Font-Objekte fehlen.

**Fix:** `dev: cairo_pdf` wird jetzt unter `format.titlepage-pdf.knitr.opts_chunk` gesetzt. Quarto mischt diesen Block per `merge_lists()` **nach** der `fig-format`-Ableitung ein und gewinnt bei Namenskollision — dort wirkt die Einstellung tatsächlich. Bewusst nur format-scoped (nicht im globalen `knitr.opts_chunk`), damit das HTML-Format `cairo_pdf` nicht abbekommt.

## Verifikation

Einzelrender von `0200-zielarten.qmd` (enthält die von KDP bemängelte Abbildung "Überlebensrate nach Geschlecht, mit/ohne Medikament"):

- Vorher: `pdffonts` zeigt `Helvetica ... emb=no` für diese Abbildung; im Gesamt-PDF ~80 nicht eingebettete Font-Objekte.
- Nachher: vollständig eingebettete `NimbusSans`-Subsets (Type 1C, `emb=yes`); Gesamt-PDF hat **0** nicht eingebettete Fonts.
- HTML-Render desselben Kapitels (`quarto render 0200-zielarten.qmd`) läuft weiterhin fehlerfrei durch (Fix ist PDF-scoped).

## Test plan

- [x] Vollständiges `./render-pdf.sh` laufen lassen und `pdffonts docs/Start-Bayes\!.pdf | grep ' no '` prüfen (sollte leer sein)
- [ ] Druckfahne stichprobenartig visuell gegenprüfen (sollte unverändert aussehen, da nur die Font-Einbettung betroffen ist, nicht das Rendering)
- [x] Neue PDF-Datei bei KDP hochladen und Validierung abwarten